### PR TITLE
Enable deployments to other clusters

### DIFF
--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -7,6 +7,9 @@ on:
         type: string
         description: "Skaffold Version"
         default: "1.33.0"
+      environment:
+        type: string
+        description: "Environment to deploy to"
     secrets:
       GCP_PROJECT_ID:
         description: "GCP Project ID"
@@ -67,9 +70,9 @@ jobs:
       - id: set-deploy-env
         name: Set the environment name from manual input or branch name
         run: |
-          if [ -n "${{ github.event.inputs.environment }}" ]; then
-            echo 'sourcing environment from manual input: ${{ github.event.inputs.environment }}'
-            echo '::set-output name=environment::${{ github.event.inputs.environment }}'
+          if [ -n "${{ inputs.environment }}" ]; then
+            echo 'sourcing environment from manual input: ${{ inputs.environment }}'
+            echo '::set-output name=environment::${{ inputs.environment }}'
             exit
           fi
 

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -34,7 +34,7 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           export_default_credentials: true
-          credentials_file_path: "/tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e"
+
       - name: Configure Docker Auth
         run: |
           gcloud --quiet auth configure-docker eu.gcr.io
@@ -58,48 +58,39 @@ jobs:
           name: build-ref
           path: build.json
 
-  deploy-development:
-    name: Deploy to development
-    if: github.event.ref == 'refs/heads/develop'
-    needs:
-      - build
+  get-deploy-env:
+    name: Get deployment environment
     runs-on: ubuntu-latest
-    environment: development
+    outputs:
+      environment: ${{ steps.set-deploy-env.outputs.environment }}
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: google-github-actions/setup-gcloud@v0.2.1
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          export_default_credentials: true
-
-      - uses: google-github-actions/get-gke-credentials@v0.3.0
-        with:
-          cluster_name: ${{ secrets.GKE_CLUSTER }}
-          location: ${{ secrets.GKE_LOCATION }}
-
-      - name: Download build reference
-        uses: actions/download-artifact@v2
-        with:
-          name: build-ref
-
-      - uses: yokawasa/action-setup-kube-tools@v0.7.1
-        with:
-          setup-tools: skaffold
-          skaffold: "${{ inputs.skaffold }}"
-
-      - name: Deploy
+      - id: set-deploy-env
+        name: Set the environment name from manual input or branch name
         run: |
-          skaffold deploy --build-artifacts=build.json
+          if [ -n "${{ github.event.inputs.environment }}" ]; then
+            echo 'sourcing environment from manual input: ${{ github.event.inputs.environment }}'
+            echo '::set-output name=environment::${{ github.event.inputs.environment }}'
+            exit
+          fi
 
-  deploy-production:
-    name: Deploy to production
-    if: github.event.ref == 'master'
+          branch="${ref#refs/heads/}"
+          if [[ "$branch" == "develop" ]]; then
+            environment="development"
+          elif [[ "$branch" == "master" ]]; then
+            environment="production"
+          fi
+
+          echo "sourcing environment from branch name: $environment"
+          echo "::set-output name=environment::$environment"
+
+
+  deploy:
+    name: Deploy
     needs:
       - build
+      - get-deploy-env
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ needs.get-deploy-env.outputs.environment }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,6 +32,11 @@ jobs:
   build:
     name: Build Docker images
     runs-on: ubuntu-latest
+    # We need to set the environment here, because environments
+    # contain our GCP credentials.
+    needs:
+      - get-deploy-env
+    environment: ${{ needs.get-deploy-env.outputs.environment }}
     if: github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/hotfix/') || startsWith(github.event.ref, 'refs/heads/deploy/') || startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build Docker images
-    if: github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.event.ref, 'refs/heads/hotfix/')
+    if: github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.event.ref, 'refs/heads/hotfix/') || startsWith(github.event.ref, 'refs/heads/deploy/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -91,6 +91,65 @@ jobs:
       - name: Deploy
         run: |
           skaffold deploy --build-artifacts=build.json
+
+  get-deploy-env:
+    name: Get deployment environment
+    if: github.event.ref == 'refs/heads/deploy/demo'
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.set-deploy-env.outputs.environment }}
+    steps:
+      - id: set-deploy-env
+        name: Set the environment name from manual input or branch name
+        run: |
+          if [ -n "${{ github.event.inputs.environment }}" ]; then
+            echo 'sourcing environment from manual input: ${{ github.event.inputs.environment }}'
+            echo '::set-output name=environment::${{ github.event.inputs.environment }}'
+          else
+            # Normalize the `master` branch into `deploy/development`
+            normalized="${GITHUB_REF/master/deploy/development}"
+            # Do the French Revolution - off with their heads!
+            environment="${normalized#refs/heads/deploy/}"
+            echo "sourcing environment from branch name: $environment"
+            echo "::set-output name=environment::$environment"
+          fi
+
+  deploy:
+    name: Deploy
+    if: startsWith(github.event.ref, 'refs/heads/deploy/')
+    needs:
+      - build
+      - get-deploy-env
+    runs-on: ubuntu-latest
+    environment: ${{ needs.get-deploy-env.outputs.environment }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          export_default_credentials: true
+
+      - uses: google-github-actions/get-gke-credentials@v0.3.0
+        with:
+          cluster_name: ${{ secrets.GKE_CLUSTER }}
+          location: ${{ secrets.GKE_LOCATION }}
+
+      - name: Download build reference
+        uses: actions/download-artifact@v2
+        with:
+          name: build-ref
+
+      - uses: yokawasa/action-setup-kube-tools@v0.7.1
+        with:
+          setup-tools: skaffold
+          skaffold: "${{ inputs.skaffold }}"
+
+      - name: Deploy
+        run: |
+          skaffold deploy --build-artifacts=build.json
+
 
   deploy-production:
     name: Deploy to production

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,6 +23,9 @@ on:
       GKE_LOCATION:
         description: "GKE Cluster Location"
         required: true
+      ssh-private-key:
+        description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies
+        required: false
 
 
 jobs:
@@ -43,10 +46,16 @@ jobs:
         run: |
           gcloud --quiet auth configure-docker eu.gcr.io
 
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: "${{ secrets.ssh-private-key }}"
+
       - uses: yokawasa/action-setup-kube-tools@v0.7.1
         with:
           setup-tools: "skaffold"
           skaffold: "${{ inputs.skaffold }}"
+
       - name: Build
         run: |
           skaffold build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,6 +7,9 @@ on:
         type: string
         description: "Skaffold Version"
         default: "1.33.0"
+      environment:
+        type: string
+        description: "Environment to deploy to"
     secrets:
       GCP_PROJECT_ID:
         description: "GCP Project ID"
@@ -21,10 +24,18 @@ on:
         description: "GKE Cluster Location"
         required: true
 
+  push:
+    branches:
+      - master
+      - hotfix/*
+      - deploy/*
+    tags:
+      - v*
+
+
 jobs:
   build:
     name: Build Docker images
-    if: github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.event.ref, 'refs/heads/hotfix/') || startsWith(github.event.ref, 'refs/heads/deploy/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -57,44 +68,8 @@ jobs:
           name: build-ref
           path: build.json
 
-  deploy-development:
-    name: Deploy to development
-    if: github.event.ref == 'refs/heads/master'
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    environment: development
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: google-github-actions/setup-gcloud@v0.2.1
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          export_default_credentials: true
-
-      - uses: google-github-actions/get-gke-credentials@v0.3.0
-        with:
-          cluster_name: ${{ secrets.GKE_CLUSTER }}
-          location: ${{ secrets.GKE_LOCATION }}
-
-      - name: Download build reference
-        uses: actions/download-artifact@v2
-        with:
-          name: build-ref
-
-      - uses: yokawasa/action-setup-kube-tools@v0.7.1
-        with:
-          setup-tools: skaffold
-          skaffold: "${{ inputs.skaffold }}"
-
-      - name: Deploy
-        run: |
-          skaffold deploy --build-artifacts=build.json
-
   get-deploy-env:
     name: Get deployment environment
-    if: github.event.ref == 'refs/heads/deploy/demo'
     runs-on: ubuntu-latest
     outputs:
       environment: ${{ steps.set-deploy-env.outputs.environment }}
@@ -105,59 +80,37 @@ jobs:
           if [ -n "${{ github.event.inputs.environment }}" ]; then
             echo 'sourcing environment from manual input: ${{ github.event.inputs.environment }}'
             echo '::set-output name=environment::${{ github.event.inputs.environment }}'
-          else
-            # Normalize the `master` branch into `deploy/development`
-            normalized="${GITHUB_REF/master/deploy/development}"
-            # Do the French Revolution - off with their heads!
-            environment="${normalized#refs/heads/deploy/}"
-            echo "sourcing environment from branch name: $environment"
-            echo "::set-output name=environment::$environment"
+            exit
           fi
+
+          # Normalize the `master` branch into `deploy/development`
+          normalized="${GITHUB_REF/master/deploy/development}"
+          ref="${normalized#refs/}"
+
+          # In this flow, we deploy to production on push to tags, and
+          # `hotfix/*` branches.
+          if [[ $ref == "tags/v*" || $ref == "heads/hotfix/*" ]]; then
+            echo "sourcing environment from tag or hotfix branch name name: production"
+            echo "::set-output name=environment::production"
+            exit
+          fi
+
+          # Otherwise, it's either a deploy branch or master branch, which
+          # we've normalized to a deploy branch.
+
+          # Do the French Revolution - off with their heads.
+          environment="${ref#heads/deploy/}"
+
+          echo "sourcing environment from branch name: $environment"
+          echo "::set-output name=environment::$environment"
 
   deploy:
     name: Deploy
-    if: startsWith(github.event.ref, 'refs/heads/deploy/')
     needs:
       - build
       - get-deploy-env
     runs-on: ubuntu-latest
     environment: ${{ needs.get-deploy-env.outputs.environment }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: google-github-actions/setup-gcloud@v0.2.1
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          export_default_credentials: true
-
-      - uses: google-github-actions/get-gke-credentials@v0.3.0
-        with:
-          cluster_name: ${{ secrets.GKE_CLUSTER }}
-          location: ${{ secrets.GKE_LOCATION }}
-
-      - name: Download build reference
-        uses: actions/download-artifact@v2
-        with:
-          name: build-ref
-
-      - uses: yokawasa/action-setup-kube-tools@v0.7.1
-        with:
-          setup-tools: skaffold
-          skaffold: "${{ inputs.skaffold }}"
-
-      - name: Deploy
-        run: |
-          skaffold deploy --build-artifacts=build.json
-
-
-  deploy-production:
-    name: Deploy to production
-    if: startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.event.ref, 'refs/heads/hotfix/')
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    environment: production
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -70,9 +70,9 @@ jobs:
       - id: set-deploy-env
         name: Set the environment name from manual input or branch name
         run: |
-          if [ -n "${{ github.event.inputs.environment }}" ]; then
-            echo 'sourcing environment from manual input: ${{ github.event.inputs.environment }}'
-            echo '::set-output name=environment::${{ github.event.inputs.environment }}'
+          if [ -n "${{ inputs.environment }}" ]; then
+            echo 'sourcing environment from manual input: ${{ inputs.environment }}'
+            echo '::set-output name=environment::${{ inputs.environment }}'
             exit
           fi
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,19 +24,12 @@ on:
         description: "GKE Cluster Location"
         required: true
 
-  push:
-    branches:
-      - master
-      - hotfix/*
-      - deploy/*
-    tags:
-      - v*
-
 
 jobs:
   build:
     name: Build Docker images
     runs-on: ubuntu-latest
+    if: github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/hotfix/') || startsWith(github.event.ref, 'refs/heads/deploy/') || startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This PR refactors both of our deploy flows (trunk-based and Gitflow) to be able to deploy to clusters other than development and production (albeit only technically when it comes to Gitflow).

This currently [succeeds for `development`](https://github.com/goes-funky/job-monitor/actions/runs/1448255761) and fails with a timeout when waiting for `demo`'s deployment to come up due to lack of a service account (to be fixed on Terraform side).

The branch schemes don't change here, except for the (temporary, and entirely convenience-driven) addition of deploy branches in the form of `deploy/<environment>`.

The plan is to DRY this further, either by compiling the workflows, or by removing Gitflow, but for the time being, let's get this out of the door as an MVP.