### PR TITLE
First generate, then lint actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ACTIONLINT := bin/actionlint-$(ACTIONLINT_VERSION)/actionlint
 
 .PHONY: $(srcs)
 
-all: lint generate
+all: generate lint
 
 tools: $(YQ) $(ACTIONLINT)
 


### PR DESCRIPTION
`make` respects order of operations.