### PR TITLE
feat: skaffold profiles for environment config nonprod vs prod

### DIFF
--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -101,7 +101,7 @@ jobs:
           skaffold: "${{ inputs.skaffold }}"
       - name: Deploy
         run: |
-          skaffold deploy --force --build-artifacts=build.json
+          skaffold deploy --profile nonprod --force --build-artifacts=build.json
   # deploy to production from inputs.production-branch
   deploy-production:
     if: "!inputs.skip-deploy && github.event.ref == format('refs/heads/{0}', inputs.production-branch)"
@@ -132,7 +132,7 @@ jobs:
           skaffold: "${{ inputs.skaffold }}"
       - name: Deploy
         run: |
-          skaffold deploy --force --build-artifacts=build.json
+          skaffold deploy --profile prod --force --build-artifacts=build.json
   build:
     name: Build Docker images
     runs-on: ubuntu-latest
@@ -212,4 +212,4 @@ jobs:
           skaffold: "${{ inputs.skaffold }}"
       - name: Deploy
         run: |
-          skaffold deploy --force --build-artifacts=build.json
+          skaffold deploy --profile nonprod --force --build-artifacts=build.json

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -96,7 +96,7 @@ jobs:
           skaffold: "${{ inputs.skaffold }}"
       - name: Deploy
         run: |
-          skaffold deploy --force --build-artifacts=build.json
+          skaffold deploy --profile nonprod --force --build-artifacts=build.json
   # deploy to production from tagged release
   deploy-production:
     if: "!inputs.skip-deploy && startsWith(github.event.ref, 'refs/tags/v')"
@@ -127,7 +127,7 @@ jobs:
           skaffold: "${{ inputs.skaffold }}"
       - name: Deploy
         run: |
-          skaffold deploy --force --build-artifacts=build.json
+          skaffold deploy --profile prod --force --build-artifacts=build.json
   build:
     name: Build Docker images
     runs-on: ubuntu-latest
@@ -207,4 +207,4 @@ jobs:
           skaffold: "${{ inputs.skaffold }}"
       - name: Deploy
         run: |
-          skaffold deploy --force --build-artifacts=build.json
+          skaffold deploy --profile nonprod --force --build-artifacts=build.json

--- a/templates/common/deploy.yaml
+++ b/templates/common/deploy.yaml
@@ -3,7 +3,7 @@ fragments:
   step-setup-gcloud: &step-setup-gcloud
     name: "Setup GCloud"
     uses: google-github-actions/setup-gcloud@v0.2.1
-  job-deploy: &job-deploy
+  job-deploy-nonprod: &job-deploy-nonprod
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,7 +27,32 @@ fragments:
           skaffold: "${{ inputs.skaffold }}"
       - name: Deploy
         run: |
-          skaffold deploy --force --build-artifacts=build.json
+          skaffold deploy --profile nonprod --force --build-artifacts=build.json
+  job-deploy-prod: &job-deploy-prod
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - <<: *step-setup-gcloud
+        with:
+          project_id: ${{ secrets.gcp-project-id }}
+          service_account_key: ${{ secrets.gcp-service-account }}
+          export_default_credentials: true
+          credentials_file_path: "/tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e"
+      - uses: google-github-actions/get-gke-credentials@v0.3.0
+        with:
+          cluster_name: ${{ secrets.gke-cluster }}
+          location: ${{ secrets.gke-location }}
+      - name: Download build reference
+        uses: actions/download-artifact@v2
+        with:
+          name: build-ref
+      - uses: yokawasa/action-setup-kube-tools@v0.7.1
+        with:
+          setup-tools: skaffold
+          skaffold: "${{ inputs.skaffold }}"
+      - name: Deploy
+        run: |
+          skaffold deploy --profile prod --force --build-artifacts=build.json
 on:
   workflow_call:
     inputs:
@@ -136,14 +161,14 @@ jobs:
     needs: [build]
     if: "inputs.environment"
     environment: ${{ inputs.environment }}
-    <<: *job-deploy
+    <<: *job-deploy-nonprod
   deploy-development:
     name: Deploy to development
     needs: [build]
     environment: ${{ inputs.development-environment }}
-    <<: *job-deploy
+    <<: *job-deploy-nonprod
   deploy-production:
     name: Deploy to production
     needs: [build, deploy-development]
     environment: ${{ inputs.production-environment }}
-    <<: *job-deploy
+    <<: *job-deploy-prod


### PR DESCRIPTION
Straightforward workaround for skaffold profiles so that deployments can have different config per environment.

I'm sure this could be done better, but this is the quickest and cleanest I can think of right now.

NOTE: This will break all workflows that use skaffold if they do not have these profiles defined. A more safe approach would be to check a profile is defined in the skaffold.yaml before attempting to activate it on the deploy.