### PR TITLE
Use the `google-github-actions/auth` action

### DIFF
--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -80,13 +80,12 @@ jobs:
     name: Deploy to development
     steps:
       - uses: actions/checkout@v2
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -112,13 +111,12 @@ jobs:
     name: Deploy to production
     steps:
       - uses: actions/checkout@v2
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -151,15 +149,19 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-gcr-project-id }}
-          service_account_key: ${{ secrets.gcp-gcr-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
-      - name: Configure Docker Auth
-        run: gcloud --quiet auth configure-docker eu.gcr.io
+          credentials_json: ${{ secrets.gcp-gcr-service-account }}
+          token_format: access_token
+      - name: Authenticate to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Setup Kubernetes tools
         uses: yokawasa/action-setup-kube-tools@v0.7.1
         with:
@@ -186,13 +188,12 @@ jobs:
     name: Deploy to environment
     steps:
       - uses: actions/checkout@v2
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -228,13 +228,12 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - name: get gke credential
         uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
@@ -275,13 +274,12 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - name: get gke credential
         uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
@@ -416,15 +414,19 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-gcr-project-id }}
-          service_account_key: ${{ secrets.gcp-gcr-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
-      - name: Configure Docker Auth
-        run: gcloud --quiet auth configure-docker eu.gcr.io
+          credentials_json: ${{ secrets.gcp-gcr-service-account }}
+          token_format: access_token
+      - name: Authenticate to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Setup Kubernetes tools
         uses: yokawasa/action-setup-kube-tools@v0.7.1
         with:
@@ -472,13 +474,12 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - name: get gke credential
         uses: google-github-actions/get-gke-credentials@v0.8.0
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,13 +75,12 @@ jobs:
     name: Deploy to development
     steps:
       - uses: actions/checkout@v2
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -107,13 +106,12 @@ jobs:
     name: Deploy to production
     steps:
       - uses: actions/checkout@v2
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -146,15 +144,19 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-gcr-project-id }}
-          service_account_key: ${{ secrets.gcp-gcr-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
-      - name: Configure Docker Auth
-        run: gcloud --quiet auth configure-docker eu.gcr.io
+          credentials_json: ${{ secrets.gcp-gcr-service-account }}
+          token_format: access_token
+      - name: Authenticate to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Setup Kubernetes tools
         uses: yokawasa/action-setup-kube-tools@v0.7.1
         with:
@@ -181,13 +183,12 @@ jobs:
     name: Deploy to environment
     steps:
       - uses: actions/checkout@v2
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to GCP
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}

--- a/pkg/common/deploy-integration.cue
+++ b/pkg/common/deploy-integration.cue
@@ -201,18 +201,14 @@ import "list"
 					}
 				},
 				#step_setup_ssh_agent,
-				#step_setup_gcloud & {
+				#step_auth_gcp & {
 					with: {
-						project_id:                 "${{ secrets.gcp-gcr-project-id }}"
-						service_account_key:        "${{ secrets.gcp-gcr-service-account }}"
-						export_default_credentials: true
-						credentials_file_path:      "/tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e"
+						project_id:       "${{ secrets.gcp-gcr-project-id }}"
+						credentials_json: "${{ secrets.gcp-gcr-service-account }}"
+						token_format:     "access_token"
 					}
 				},
-				{
-					name: "Configure Docker Auth"
-					run:  "gcloud --quiet auth configure-docker eu.gcr.io"
-				},
+				#step_auth_gcr,
 				{
 					name: "Setup Kubernetes tools"
 					uses: "yokawasa/action-setup-kube-tools@v0.7.1"
@@ -338,12 +334,10 @@ import "list"
 	deploy_integration: [
 		#step_checkout,
 		#step_setup_ssh_agent,
-		#step_setup_gcloud & {
+		#step_auth_gcp & {
 			with: {
-				project_id:                 "${{ secrets.gcp-project-id }}"
-				service_account_key:        "${{ secrets.gcp-service-account }}"
-				export_default_credentials: true
-				credentials_file_path:      "/tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e"
+				project_id:       "${{ secrets.gcp-project-id }}"
+				credentials_json: "${{ secrets.gcp-service-account }}"
 			}
 		},
 		{

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -123,19 +123,15 @@ import "list"
 			}
 		},
 		#step_setup_ssh_agent,
-		#step_setup_gcloud & {
+		#step_auth_gcp & {
 			with: {
 
-				project_id:                 "${{ secrets.gcp-gcr-project-id }}"
-				service_account_key:        "${{ secrets.gcp-gcr-service-account }}"
-				export_default_credentials: true
-				credentials_file_path:      "/tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e"
+				project_id:       "${{ secrets.gcp-gcr-project-id }}"
+				credentials_json: "${{ secrets.gcp-gcr-service-account }}"
+				token_format:     "access_token"
 			}
 		},
-		{
-			name: "Configure Docker Auth"
-			run:  "gcloud --quiet auth configure-docker eu.gcr.io"
-		},
+		#step_auth_gcr,
 		{
 			name: "Setup Kubernetes tools"
 			uses: "yokawasa/action-setup-kube-tools@v0.7.1"
@@ -197,12 +193,10 @@ import "list"
 		{
 		uses: "actions/checkout@v2"
 	},
-	#step_setup_gcloud & {
+	#step_auth_gcp & {
 		with: {
-			project_id:                 "${{ secrets.gcp-project-id }}"
-			service_account_key:        "${{ secrets.gcp-service-account }}"
-			export_default_credentials: true
-			credentials_file_path:      "/tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e"
+			project_id:       "${{ secrets.gcp-project-id }}"
+			credentials_json: "${{ secrets.gcp-service-account }}"
 		}
 	},
 	{
@@ -227,7 +221,18 @@ import "list"
 	},
 ]
 
-#step_setup_gcloud: #step & {
-	name: "Setup GCloud"
-	uses: "google-github-actions/setup-gcloud@v0.2.1"
+#step_auth_gcp: #step & {
+	id: "auth_gcp"
+	name: "Authenticate to GCP"
+	uses: "google-github-actions/auth@v0"
+}
+
+#step_auth_gcr: #step & {
+	name: "Authenticate to GCR"
+	uses: "docker/login-action@v1"
+	with: {
+		registry: "eu.gcr.io"
+		username: "oauth2accesstoken"
+		password: "${{ steps.auth_gcp.outputs.access_token }}"
+	}
 }


### PR DESCRIPTION
The `setup-gcloud` action's authentication behavior has been deprecated,
and this action is recommended instead.

Do integrations upload in a separate PR, to limit blast radius.