### PR TITLE
feat: make ssh-private-key optional for python build

### DIFF
--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -46,7 +46,7 @@ name: Build Python
     secrets:
       ssh-private-key:
         description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies
-        required: true
+        required: false
       codecov-token:
         description: Token to upload coverage reports to codecov
         required: false
@@ -77,6 +77,7 @@ jobs:
           virtualenvs-in-project: true
       - name: Setup SSH Agent
         uses: webfactory/ssh-agent@v0.5.4
+        if: "${{ secrets.ssh-private-key != '' }}"
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
       - name: Configure setup tools for poetry


### PR DESCRIPTION
In https://github.com/goes-funky/tap-bing-ads/pull/4 we try to use the build-python configuration on a public repository. Public repositories don't have access to org secrets and, therefore, the current setup fails. Hence, we try to skip the SSH agent configuration in case no value is provided.