### PR TITLE
feat: ignore ssh agent setup when env missing

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -10,6 +10,10 @@ name: Build Go
         type: string
         description: Go version
         default: "1.17"
+      is-repo-public:
+        type: boolean
+        description: Whether to skip ssh agent configuration
+        default: false
     secrets:
       ssh-private-key:
         description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -13,7 +13,7 @@ name: Build Go
     secrets:
       ssh-private-key:
         description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies
-        required: true
+        required: false
 jobs:
   tools:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -76,7 +76,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
-        if: "${{ secrets.ssh-private-key != '' }}"
+        if: secrets.ssh-private-key
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -76,7 +76,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
-        if: ${{ secrets.ssh-private-key != '' }}
+        if: "${{ secrets.ssh-private-key != '' }}"
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -46,7 +46,7 @@ name: Build Python
     secrets:
       ssh-private-key:
         description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies
-        required: true
+        required: false
       codecov-token:
         description: Token to upload coverage reports to codecov
         required: false
@@ -76,6 +76,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
+        if: ${{ secrets.ssh-private-key != '' }}
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -76,7 +76,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
-        if: secrets.ssh-private-key
+        if: '!!secrets.ssh-private-key'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -39,6 +39,10 @@ name: Build Python
         type: boolean
         description: Whether to skip running tests
         default: true
+      is-repo-public:
+        type: boolean
+        description: Whether to skip ssh agent configuration
+        default: false
       skip-mypy:
         type: boolean
         description: Whether to skip checking type hints with mypy
@@ -76,7 +80,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
-        if: '!!secrets.ssh-private-key'
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -148,6 +148,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
+        if: ${{ secrets.ssh-private-key != '' }}
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -148,7 +148,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
-        if: secrets.ssh-private-key
+        if: '!!secrets.ssh-private-key'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -148,7 +148,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
-        if: ${{ secrets.ssh-private-key != '' }}
+        if: secrets.ssh-private-key
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -2,6 +2,10 @@ name: Deploy
 "on":
   workflow_call:
     inputs:
+      is-repo-public:
+        type: boolean
+        description: Whether to skip ssh agent configuration
+        default: false
       skaffold:
         type: string
         description: Skaffold version
@@ -148,7 +152,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
-        if: '!!secrets.ssh-private-key'
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -2,6 +2,10 @@ name: Deploy Integration
 "on":
   workflow_call:
     inputs:
+      is-repo-public:
+        type: boolean
+        description: Whether to skip ssh agent configuration
+        default: false
       skaffold:
         type: string
         description: Skaffold version
@@ -225,7 +229,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
-        if: '!!secrets.ssh-private-key'
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -273,7 +277,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
-        if: '!!secrets.ssh-private-key'
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -333,7 +337,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
-        if: '!!secrets.ssh-private-key'
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -416,7 +420,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
-        if: '!!secrets.ssh-private-key'
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -473,7 +477,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
-        if: '!!secrets.ssh-private-key'
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -225,7 +225,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
-        if: ${{ secrets.ssh-private-key != '' }}
+        if: secrets.ssh-private-key
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -273,7 +273,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
-        if: ${{ secrets.ssh-private-key != '' }}
+        if: secrets.ssh-private-key
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -333,7 +333,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
-        if: ${{ secrets.ssh-private-key != '' }}
+        if: secrets.ssh-private-key
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -416,7 +416,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
-        if: ${{ secrets.ssh-private-key != '' }}
+        if: secrets.ssh-private-key
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -473,7 +473,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
-        if: ${{ secrets.ssh-private-key != '' }}
+        if: secrets.ssh-private-key
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -225,7 +225,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
-        if: secrets.ssh-private-key
+        if: '!!secrets.ssh-private-key'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -273,7 +273,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
-        if: secrets.ssh-private-key
+        if: '!!secrets.ssh-private-key'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -333,7 +333,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
-        if: secrets.ssh-private-key
+        if: '!!secrets.ssh-private-key'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -416,7 +416,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
-        if: secrets.ssh-private-key
+        if: '!!secrets.ssh-private-key'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -473,7 +473,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
-        if: secrets.ssh-private-key
+        if: '!!secrets.ssh-private-key'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -225,6 +225,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
+        if: ${{ secrets.ssh-private-key != '' }}
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -272,6 +273,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
+        if: ${{ secrets.ssh-private-key != '' }}
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -331,6 +333,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
+        if: ${{ secrets.ssh-private-key != '' }}
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -413,6 +416,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
+        if: ${{ secrets.ssh-private-key != '' }}
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -469,6 +473,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
+        if: ${{ secrets.ssh-private-key != '' }}
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -143,7 +143,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
-        if: secrets.ssh-private-key
+        if: '!!secrets.ssh-private-key'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -143,7 +143,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
-        if: ${{ secrets.ssh-private-key != '' }}
+        if: secrets.ssh-private-key
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -143,6 +143,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
+        if: ${{ secrets.ssh-private-key != '' }}
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,10 @@ name: Deploy
 "on":
   workflow_call:
     inputs:
+      is-repo-public:
+        type: boolean
+        description: Whether to skip ssh agent configuration
+        default: false
       skaffold:
         type: string
         description: Skaffold version
@@ -143,7 +147,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
-        if: '!!secrets.ssh-private-key'
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/pkg/common/build.cue
+++ b/pkg/common/build.cue
@@ -10,6 +10,11 @@ package common
 					description: "Whether to skip checkout"
 					default:     false
 				}
+				"is-repo-public": {
+					type:        "boolean"
+					description: "Whether to skip ssh agent configuration"
+					default:     false
+				}
 				...
 			}
 			secrets: {
@@ -31,7 +36,7 @@ package common
 
 #step_setup_ssh_agent: #step & {
 	name: "Setup SSH Agent"
-	if: "!!secrets.ssh-private-key"
+	if: "!inputs.is-repo-public"
 	uses: "webfactory/ssh-agent@v0.5.4"
 	with: {
 		"ssh-private-key": "${{ secrets.ssh-private-key }}"

--- a/pkg/common/build.cue
+++ b/pkg/common/build.cue
@@ -35,5 +35,5 @@ package common
 	with: {
 		"ssh-private-key": "${{ secrets.ssh-private-key }}"
 	}
-	if: "${{ secrets.ssh-private-key != '' }}"
+	if: "secrets.ssh-private-key"
 }

--- a/pkg/common/build.cue
+++ b/pkg/common/build.cue
@@ -15,7 +15,7 @@ package common
 			secrets: {
 				"ssh-private-key": {
 					description: "SSH private key used to authenticate to GitHub with, in order to fetch private dependencies"
-					required:    true
+					required:    false
 				}
 				...
 			}
@@ -35,4 +35,5 @@ package common
 	with: {
 		"ssh-private-key": "${{ secrets.ssh-private-key }}"
 	}
+	if: "${{ secrets.ssh-private-key != '' }}"
 }

--- a/pkg/common/build.cue
+++ b/pkg/common/build.cue
@@ -31,9 +31,9 @@ package common
 
 #step_setup_ssh_agent: #step & {
 	name: "Setup SSH Agent"
+	if: "!!secrets.ssh-private-key"
 	uses: "webfactory/ssh-agent@v0.5.4"
 	with: {
 		"ssh-private-key": "${{ secrets.ssh-private-key }}"
 	}
-	if: "secrets.ssh-private-key"
 }

--- a/pkg/common/deploy-integration.cue
+++ b/pkg/common/deploy-integration.cue
@@ -6,6 +6,11 @@ import "list"
 	on: {
 		workflow_call: {
 			inputs: {
+				"is-repo-public": {
+					type:        "boolean"
+					description: "Whether to skip ssh agent configuration"
+					default:     false
+				}
 				"skaffold": {
 					type:        "string"
 					description: "Skaffold version"

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -6,6 +6,11 @@ import "list"
 	on: {
 		workflow_call: {
 			inputs: {
+				"is-repo-public": {
+					type:        "boolean"
+					description: "Whether to skip ssh agent configuration"
+					default:     false
+				}
 				"skaffold": {
 					type:        "string"
 					description: "Skaffold version"


### PR DESCRIPTION
Trying https://github.com/goes-funky/workflows/pull/43 again.

According to this (https://github.com/actions/runner/issues/520) issue, one cannot use secrets for conditional jobs. Including the workarounds in the issue we end up with three options:

1. Add an explicit flag to indicate if a repo is public (approach in this PR). If a repo is public, we skip the SSH login. For an example see https://github.com/goes-funky/tap-bing-ads/pull/7.
2. We could try to get the public/private status from the GitHub API (it's not part of the build context). This would entail a more complicated job setup here in cue, but would remove the need for additional flags. IMO not preferable, because the default (private) is used across most repositories anyway.
3. Use the [workaround](https://github.com/actions/runner/issues/520#issuecomment-907427748) mentioned in the GitHub issue:
```yaml
  check-env:
      outputs:
        my-key: ${{ steps.my-key.outputs.defined }}
      steps:
          - id: my-key
            env:
                MY_KEY: ${{ secrets.MY_KEY }}
            if: "${{ env.MY_KEY != '' }}"
            run: echo "::set-output name=defined::true"

  next-job:
        needs: [check-env]
        if: needs.check-env.outputs.my-key == 'true'
        ...
```
This should work without additional flags and API requests, but some people already report issues and it will be complicated to integrate into our CUE setup. 

IMO the explicit flag is the cleanest solution and doesn't require any changes to the existing setups. Let me know what you think.