### PR TITLE
TECH-9424: ignore ssh-agent for public workflows

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -10,10 +10,14 @@ name: Build Go
         type: boolean
         description: Whether to skip checkout
         default: false
+      is-repo-public:
+        type: boolean
+        description: Whether to skip ssh agent configuration
+        default: false
     secrets:
       ssh-private-key:
         description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies
-        required: true
+        required: false
 jobs:
   tools:
     runs-on: ubuntu-latest
@@ -57,7 +61,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
         if: '!steps.deps-cache.outputs.cache-hit'
       - name: Setup SSH Agent
-        if: '!steps.deps-cache.outputs.cache-hit'
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -43,6 +43,10 @@ name: Build Python
         type: boolean
         description: Whether to skip checkout
         default: false
+      is-repo-public:
+        type: boolean
+        description: Whether to skip ssh agent configuration
+        default: false
       skip-sonar:
         type: boolean
         description: Whether to skip sonarcloud scans
@@ -53,7 +57,7 @@ name: Build Python
         required: false
       ssh-private-key:
         description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies
-        required: true
+        required: false
       codecov-token:
         description: Keep around until all workflows are migrated
         required: false
@@ -83,6 +87,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -32,6 +32,10 @@ name: Deploy
         type: string
         description: Skaffold version
         default: 1.33.0
+      is-repo-public:
+        type: boolean
+        description: Whether to skip ssh agent configuration
+        default: false
       development-branch:
         type: string
         description: Development branch
@@ -65,7 +69,7 @@ name: Deploy
         required: true
       ssh-private-key:
         description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies
-        required: true
+        required: false
       gcp-gcr-service-account:
         description: GCP GCR Service Account Key
         required: true
@@ -160,6 +164,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -66,6 +66,10 @@ name: Deploy Integration
         type: string
         description: Skaffold version
         default: 1.33.0
+      is-repo-public:
+        type: boolean
+        description: Whether to skip ssh agent configuration
+        default: false
       development-branch:
         type: string
         description: Development branch
@@ -97,7 +101,7 @@ name: Deploy Integration
         required: true
       ssh-private-key:
         description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies
-        required: true
+        required: false
       gcp-gcr-service-account:
         description: GCP GCR Service Account Key
         required: true
@@ -225,6 +229,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -271,6 +276,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -329,6 +335,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Setup SSH Agent
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -412,6 +419,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
@@ -468,6 +476,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v2
       - name: Setup SSH Agent
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,6 +32,10 @@ name: Deploy
         type: string
         description: Skaffold version
         default: 1.33.0
+      is-repo-public:
+        type: boolean
+        description: Whether to skip ssh agent configuration
+        default: false
       development-branch:
         type: string
         description: Development branch
@@ -60,7 +64,7 @@ name: Deploy
         required: true
       ssh-private-key:
         description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies
-        required: true
+        required: false
       gcp-gcr-service-account:
         description: GCP GCR Service Account Key
         required: true
@@ -155,6 +159,7 @@ jobs:
           name: ${{ inputs.dist-artifact }}
           path: dist
       - name: Setup SSH Agent
+        if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/pkg/common/deploy-integration.cue
+++ b/pkg/common/deploy-integration.cue
@@ -8,6 +8,7 @@ import "list"
 			inputs: {
 				#with.checkout.inputs
 				#with.kube_tools.inputs
+				#with.ssh_agent.inputs
 				"environment": {
 					type:        "string"
 					description: "Deployment environment"

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -8,6 +8,7 @@ import "list"
 			inputs: {
 				#with.checkout.inputs
 				#with.kube_tools.inputs
+				#with.ssh_agent.inputs
 				"environment": {
 					type:        "string"
 					description: "Deployment environment"

--- a/pkg/common/steps.cue
+++ b/pkg/common/steps.cue
@@ -19,16 +19,25 @@ package common
 	}
 
 	ssh_agent: {
+	    inputs: {
+	    	"is-repo-public": {
+                type:        "boolean"
+                description: "Whether to skip ssh agent configuration"
+                default:     false
+            }
+	    }
+
 		secrets: {
 			"ssh-private-key": {
 				description: "SSH private key used to authenticate to GitHub with, in order to fetch private dependencies"
-				required:    true
+				required:    false
 			}
 		}
 
 		step: #step & {
 			name: "Setup SSH Agent"
 			uses: "webfactory/ssh-agent@v0.5.4"
+			if: "!inputs.is-repo-public"
 			with: {
 				"ssh-private-key": "${{ secrets.ssh-private-key }}"
 			}

--- a/pkg/workflows/build-go.cue
+++ b/pkg/workflows/build-go.cue
@@ -36,6 +36,7 @@ common.#workflow & {
 		workflow_call: {
 			inputs: {
 				common.#with.checkout.inputs
+				common.#with.ssh_agent.inputs
 				"go-version": {
 					type:        "string"
 					description: "Go version"
@@ -80,9 +81,7 @@ common.#workflow & {
 					with: "go-version": "${{ inputs.go-version }}"
 					if: "!steps.deps-cache.outputs.cache-hit"
 				},
-				common.#with.ssh_agent.step & {
-					if: "!steps.deps-cache.outputs.cache-hit"
-				},
+				common.#with.ssh_agent.step,
 				{
 					name: "Download dependencies"
 					if:   "!steps.deps-cache.outputs.cache-hit"

--- a/pkg/workflows/build-python.cue
+++ b/pkg/workflows/build-python.cue
@@ -37,6 +37,7 @@ common.#workflow & {
 		workflow_call: {
 			inputs: {
 				common.#with.checkout.inputs
+				common.#with.ssh_agent.inputs
 				"python-version": {
 					type:        "string"
 					description: "Python version"


### PR DESCRIPTION
Ignore the ssh-agent task if the repo is flagged as public. In those cases we don't provide the environment so it would fail anyway.