### PR TITLE
TECH-9082: accept skaffold filename param in deploy flow

### DIFF
--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -116,7 +116,7 @@ jobs:
       - name: Deploy
         env:
           SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
-        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --force --build-artifacts=build.json
+        run: skaffold deploy --filename=${{ inputs.skaffold-file }} --force --build-artifacts=build.json
   deploy-production:
     needs:
       - build
@@ -149,7 +149,7 @@ jobs:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}
       - name: Deploy
-        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --profile prod --force --build-artifacts=build.json
+        run: skaffold deploy --filename=${{ inputs.skaffold-file }} --profile prod --force --build-artifacts=build.json
   build:
     runs-on: ubuntu-latest
     name: Build Docker images
@@ -192,7 +192,7 @@ jobs:
       - name: Configure Skaffold
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
       - name: Build
-        run: skaffold build --file-name=${{ inputs.skaffold-file }} --file-output=build.json
+        run: skaffold build --filename=${{ inputs.skaffold-file }} --file-output=build.json
       - name: Archive build reference
         uses: actions/upload-artifact@v2
         with:
@@ -231,4 +231,4 @@ jobs:
       - name: Deploy
         env:
           SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
-        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --force --build-artifacts=build.json
+        run: skaffold deploy --filename=${{ inputs.skaffold-file }} --force --build-artifacts=build.json

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -24,6 +24,10 @@ name: Deploy
         type: string
         description: Dist artifact name
         required: false
+      skip-deploy:
+        type: boolean
+        description: Skip deployment to cluster
+        required: false
       skip-checkout:
         type: boolean
         description: Whether to skip checkout
@@ -41,10 +45,10 @@ name: Deploy
         description: Development branch
         default: develop
         required: false
-      skip-deploy:
-        type: boolean
-        description: Skip deployment to cluster
-        required: false
+      skaffold-file:
+        type: string
+        description: Skaffold file to use
+        default: skaffold.yaml
       kubeval:
         type: string
         description: Kubeval version
@@ -112,7 +116,7 @@ jobs:
       - name: Deploy
         env:
           SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
-        run: skaffold deploy --force --build-artifacts=build.json
+        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --force --build-artifacts=build.json
   deploy-production:
     needs:
       - build
@@ -145,7 +149,7 @@ jobs:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}
       - name: Deploy
-        run: skaffold deploy --profile prod --force --build-artifacts=build.json
+        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --profile prod --force --build-artifacts=build.json
   build:
     runs-on: ubuntu-latest
     name: Build Docker images
@@ -188,7 +192,7 @@ jobs:
       - name: Configure Skaffold
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
       - name: Build
-        run: skaffold build --file-output=build.json
+        run: skaffold build --file-name=${{ inputs.skaffold-file }} --file-output=build.json
       - name: Archive build reference
         uses: actions/upload-artifact@v2
         with:
@@ -227,4 +231,4 @@ jobs:
       - name: Deploy
         env:
           SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
-        run: skaffold deploy --force --build-artifacts=build.json
+        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --force --build-artifacts=build.json

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Deploy
         env:
           SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
-        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --force --build-artifacts=build.json
+        run: skaffold deploy --filename=${{ inputs.skaffold-file }} --force --build-artifacts=build.json
   deploy-production:
     needs:
       - build
@@ -144,7 +144,7 @@ jobs:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}
       - name: Deploy
-        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --profile prod --force --build-artifacts=build.json
+        run: skaffold deploy --filename=${{ inputs.skaffold-file }} --profile prod --force --build-artifacts=build.json
   build:
     runs-on: ubuntu-latest
     name: Build Docker images
@@ -187,7 +187,7 @@ jobs:
       - name: Configure Skaffold
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
       - name: Build
-        run: skaffold build --file-name=${{ inputs.skaffold-file }} --file-output=build.json
+        run: skaffold build --filename=${{ inputs.skaffold-file }} --file-output=build.json
       - name: Archive build reference
         uses: actions/upload-artifact@v2
         with:
@@ -226,4 +226,4 @@ jobs:
       - name: Deploy
         env:
           SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
-        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --force --build-artifacts=build.json
+        run: skaffold deploy --filename=${{ inputs.skaffold-file }} --force --build-artifacts=build.json

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,10 @@ name: Deploy
         type: string
         description: Dist artifact name
         required: false
+      skip-deploy:
+        type: boolean
+        description: Skip deployment to cluster
+        required: false
       skip-checkout:
         type: boolean
         description: Whether to skip checkout
@@ -41,10 +45,10 @@ name: Deploy
         description: Development branch
         default: ${{ github.event.repository.default_branch }}
         required: false
-      skip-deploy:
-        type: boolean
-        description: Skip deployment to cluster
-        required: false
+      skaffold-file:
+        type: string
+        description: Skaffold file to use
+        default: skaffold.yaml
       kubeval:
         type: string
         description: Kubeval version
@@ -107,7 +111,7 @@ jobs:
       - name: Deploy
         env:
           SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
-        run: skaffold deploy --force --build-artifacts=build.json
+        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --force --build-artifacts=build.json
   deploy-production:
     needs:
       - build
@@ -140,7 +144,7 @@ jobs:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}
       - name: Deploy
-        run: skaffold deploy --profile prod --force --build-artifacts=build.json
+        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --profile prod --force --build-artifacts=build.json
   build:
     runs-on: ubuntu-latest
     name: Build Docker images
@@ -183,7 +187,7 @@ jobs:
       - name: Configure Skaffold
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
       - name: Build
-        run: skaffold build --file-output=build.json
+        run: skaffold build --file-name=${{ inputs.skaffold-file }} --file-output=build.json
       - name: Archive build reference
         uses: actions/upload-artifact@v2
         with:
@@ -222,4 +226,4 @@ jobs:
       - name: Deploy
         env:
           SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
-        run: skaffold deploy --force --build-artifacts=build.json
+        run: skaffold deploy --file-name=${{ inputs.skaffold-file }} --force --build-artifacts=build.json

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -116,7 +116,7 @@ import "list"
 		},
 		{
 			name: "Build"
-			run:  "skaffold build --file-name=${{ inputs.skaffold-file }} --file-output=build.json"
+			run:  "skaffold build --filename=${{ inputs.skaffold-file }} --file-output=build.json"
 		},
 		{
 			name: "Archive build reference"
@@ -138,7 +138,7 @@ import "list"
 					env: {
 						SKAFFOLD_PROFILE: "${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}"
 					}
-					run: "skaffold deploy --file-name=${{ inputs.skaffold-file }} --force --build-artifacts=build.json"
+					run: "skaffold deploy --filename=${{ inputs.skaffold-file }} --force --build-artifacts=build.json"
 				},
 			]])
 }
@@ -149,7 +149,7 @@ import "list"
 			#steps_deploy, [
 				{
 					name: "Deploy"
-					run:  "skaffold deploy --file-name=${{ inputs.skaffold-file }} --profile prod --force --build-artifacts=build.json"
+					run:  "skaffold deploy --filename=${{ inputs.skaffold-file }} --profile prod --force --build-artifacts=build.json"
 				},
 			]])
 }

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -37,9 +37,14 @@ import "list"
 					required:    false
 				}
 				"skip-deploy": {
-					type:        "boolean"
-					description: "Skip deployment to cluster"
-					required:    false
+                	type:        "boolean"
+                	description: "Skip deployment to cluster"
+                	required:    false
+                }
+				"skaffold-file": {
+					type:        "string"
+					description: "Skaffold file to use"
+					default:    "skaffold.yaml"
 				}
 				...
 			}
@@ -111,7 +116,7 @@ import "list"
 		},
 		{
 			name: "Build"
-			run:  "skaffold build --file-output=build.json"
+			run:  "skaffold build --file-name=${{ inputs.skaffold-file }} --file-output=build.json"
 		},
 		{
 			name: "Archive build reference"
@@ -133,7 +138,7 @@ import "list"
 					env: {
 						SKAFFOLD_PROFILE: "${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}"
 					}
-					run: "skaffold deploy --force --build-artifacts=build.json"
+					run: "skaffold deploy --file-name=${{ inputs.skaffold-file }} --force --build-artifacts=build.json"
 				},
 			]])
 }
@@ -144,7 +149,7 @@ import "list"
 			#steps_deploy, [
 				{
 					name: "Deploy"
-					run:  "skaffold deploy --profile prod --force --build-artifacts=build.json"
+					run:  "skaffold deploy --file-name=${{ inputs.skaffold-file }} --profile prod --force --build-artifacts=build.json"
 				},
 			]])
 }


### PR DESCRIPTION
### Issue

https://app.clickup.com/t/2575789/TECH-9082

### What

To support a mono-repo deployment, we need multiple skaffold files. With this change we allow users to provide a custom skaffold file name in the config. It will still default to skaffold.yaml for all other repositories.

c.f. https://github.com/goes-funky/y42-frontend/pull/2009