### PR TITLE
TECH-8858: Migrate to the new GCP auth action

### DIFF
--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -90,13 +90,12 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -125,13 +124,12 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -168,15 +166,20 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-gcr-project-id }}
-          service_account_key: ${{ secrets.gcp-gcr-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
-      - name: Configure Docker Auth
-        run: gcloud --quiet auth configure-docker eu.gcr.io
+          credentials_json: ${{ secrets.gcp-gcr-service-account }}
+          token_format: access_token
+      - name: Authenticate to Google Container Registry
+        id: auth_gcr
+        uses: docker/login-action@v1
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Setup Kubernetes tools
         uses: yokawasa/action-setup-kube-tools@v0.7.1
         with:
@@ -205,13 +208,12 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -150,13 +150,12 @@ jobs:
           KAFKA_SASL_SECRET='' export KAFKA_SASL_SECRET
           CONTAINER_MODULE=$(basename -s .git "$(git remote get-url origin | sed 's/-/_/g')" ) export CONTAINER_MODULE
           eval "$GENERATE_SCHEMA_COMMAND"
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - name: Upload Integration schema to JSON schema folder
         uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
@@ -204,13 +203,12 @@ jobs:
           KAFKA_SASL_SECRET='' export KAFKA_SASL_SECRET
           CONTAINER_MODULE=$(basename -s .git "$(git remote get-url origin | sed 's/-/_/g')" ) export CONTAINER_MODULE
           eval "$GENERATE_SCHEMA_COMMAND"
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - name: Upload Integration schema to JSON schema folder
         uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
@@ -233,13 +231,12 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -280,13 +277,12 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -387,13 +383,12 @@ jobs:
           KAFKA_SASL_SECRET='' export KAFKA_SASL_SECRET
           CONTAINER_MODULE=$(basename -s .git "$(git remote get-url origin | sed 's/-/_/g')" ) export CONTAINER_MODULE
           eval "$GENERATE_SCHEMA_COMMAND"
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - name: Upload Integration schema to JSON schema folder
         uses: google-github-actions/upload-cloud-storage@v0.8.0
         with:
@@ -423,15 +418,20 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-gcr-project-id }}
-          service_account_key: ${{ secrets.gcp-gcr-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
-      - name: Configure Docker Auth
-        run: gcloud --quiet auth configure-docker eu.gcr.io
+          credentials_json: ${{ secrets.gcp-gcr-service-account }}
+          token_format: access_token
+      - name: Authenticate to Google Container Registry
+        id: auth_gcr
+        uses: docker/login-action@v1
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Setup Kubernetes tools
         uses: yokawasa/action-setup-kube-tools@v0.7.1
         with:
@@ -480,13 +480,12 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -85,13 +85,12 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -120,13 +119,12 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -163,15 +161,20 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-gcr-project-id }}
-          service_account_key: ${{ secrets.gcp-gcr-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
-      - name: Configure Docker Auth
-        run: gcloud --quiet auth configure-docker eu.gcr.io
+          credentials_json: ${{ secrets.gcp-gcr-service-account }}
+          token_format: access_token
+      - name: Authenticate to Google Container Registry
+        id: auth_gcr
+        uses: docker/login-action@v1
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Setup Kubernetes tools
         uses: yokawasa/action-setup-kube-tools@v0.7.1
         with:
@@ -200,13 +203,12 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+      - name: Authenticate to Google Cloud
+        id: auth_gcp
+        uses: google-github-actions/auth@v0
         with:
           project_id: ${{ secrets.gcp-project-id }}
-          service_account_key: ${{ secrets.gcp-service-account }}
-          export_default_credentials: true
-          credentials_file_path: /tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e
+          credentials_json: ${{ secrets.gcp-service-account }}
       - uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ${{ secrets.gke-cluster }}

--- a/pkg/common/deploy-integration.cue
+++ b/pkg/common/deploy-integration.cue
@@ -109,7 +109,7 @@ import "list"
 			name: "Upload Integration Schema to dev"
 			needs: ["deps", "build"]
 			environment: "${{ inputs.development-environment }}"
-			steps: #integration_steps.json_scheme_generate
+			steps:       #integration_steps.json_scheme_generate
 		}
 
 		"integration-schema-generate-production": {
@@ -117,25 +117,25 @@ import "list"
 			needs: ["deps", "build", "integration-schema-generate-development", "deploy-development"]
 			if:          string | *"inputs.environment"
 			environment: "${{ inputs.production-environment }}"
-			steps: #integration_steps.json_scheme_generate
+			steps:       #integration_steps.json_scheme_generate
 		}
 
 		"deploy-development": {
 			name: "Deploy to development"
 			needs: ["build"]
 			environment: "${{ inputs.development-environment }}"
-			steps: #integration_steps.deploy_integration
+			steps:       #integration_steps.deploy_integration
 		}
 
 		"deploy-production": {
 			name: "Deploy to production"
 			needs: ["build", "deploy-development"]
 			environment: "${{ inputs.production-environment }}"
-			steps: #integration_steps.deploy_integration
+			steps:       #integration_steps.deploy_integration
 		}
 
 		deps: {
-			name: "Dependencies"
+			name:  "Dependencies"
 			steps: #integration_steps.dependencies
 		}
 
@@ -144,7 +144,7 @@ import "list"
 			needs: ["deps", "build"]
 			if:          "inputs.environment"
 			environment: "${{ inputs.environment }}"
-			steps: #integration_steps.json_scheme_generate
+			steps:       #integration_steps.json_scheme_generate
 		}
 
 		build: {
@@ -171,10 +171,9 @@ import "list"
 				#with.ssh_agent.step,
 				#with.gcloud.step & {
 					with: {
-						project_id:                 "${{ secrets.gcp-gcr-project-id }}"
-						service_account_key:        "${{ secrets.gcp-gcr-service-account }}"
-						export_default_credentials: true
-						credentials_file_path:      "/tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e"
+						project_id:       "${{ secrets.gcp-gcr-project-id }}"
+						credentials_json: "${{ secrets.gcp-gcr-service-account }}"
+						token_format:     "access_token"
 					}
 				},
 				#with.docker_auth.step,
@@ -222,7 +221,7 @@ import "list"
 			needs: ["build"]
 			if:          "inputs.environment"
 			environment: "${{ inputs.environment }}"
-			steps: #integration_steps.deploy_integration
+			steps:       #integration_steps.deploy_integration
 		}
 	}
 }
@@ -284,10 +283,8 @@ import "list"
 		#with.ssh_agent.step,
 		#with.gcloud.step & {
 			with: {
-				project_id:                 "${{ secrets.gcp-project-id }}"
-				service_account_key:        "${{ secrets.gcp-service-account }}"
-				export_default_credentials: true
-				credentials_file_path:      "/tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e"
+				project_id:       "${{ secrets.gcp-project-id }}"
+				credentials_json: "${{ secrets.gcp-service-account }}"
 			}
 		},
 		#with.gke.step,
@@ -307,8 +304,8 @@ import "list"
 		},
 		{
 			name: "Deploy"
-			if:  "inputs.skip-job-template-build"
-			run: "skaffold deploy --force --build-artifacts=build.json"
+			if:   "inputs.skip-job-template-build"
+			run:  "skaffold deploy --force --build-artifacts=build.json"
 		},
 		{
 			name: "Deploy tap container with job-template"

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -63,7 +63,7 @@ import "list"
 			needs: ["build", "deploy-development"]
 		}
 
-		build:                #job_build
+		build: #job_build
 
 		"deploy-environment": #job_deploy_nonprod & {
 			name:        "Deploy to environment"
@@ -97,10 +97,9 @@ import "list"
 		#with.ssh_agent.step,
 		#with.gcloud.step & {
 			with: {
-				project_id:                 "${{ secrets.gcp-gcr-project-id }}"
-				service_account_key:        "${{ secrets.gcp-gcr-service-account }}"
-				export_default_credentials: true
-				credentials_file_path:      "/tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e"
+				project_id:       "${{ secrets.gcp-gcr-project-id }}"
+				credentials_json: "${{ secrets.gcp-gcr-service-account }}"
+				token_format:     "access_token"
 			}
 		},
 		#with.docker_auth.step,
@@ -150,10 +149,10 @@ import "list"
 }
 
 #steps_deploy: [...#step] & [
-	#with.checkout.step,
-	#with.gcloud.step,
-	#with.gke.step,
-	{
+		#with.checkout.step,
+		#with.gcloud.step,
+		#with.gke.step,
+		{
 		name: "Download build reference"
 		uses: "actions/download-artifact@v2"
 		with: {

--- a/pkg/common/steps.cue
+++ b/pkg/common/steps.cue
@@ -93,13 +93,12 @@ package common
 		}
 
 		step: #step & {
-			name: "Setup GCloud"
-			uses: "google-github-actions/setup-gcloud@v0.2.1"
+			id: "auth_gcp"
+			name: "Authenticate to Google Cloud"
+			uses: "google-github-actions/auth@v0"
 			with: {} | *{
 				project_id:                 "${{ secrets.gcp-project-id }}"
-				service_account_key:        "${{ secrets.gcp-service-account }}"
-				export_default_credentials: true
-				credentials_file_path:      "/tmp/2143f99e-4ec1-11ec-9d55-cbf168cabc9e"
+				credentials_json:           "${{ secrets.gcp-service-account }}"
 			}
 		}
 	}
@@ -126,8 +125,14 @@ package common
 
 	docker_auth: {
 		step: #step & {
-			name: "Configure Docker Auth"
-			run:  "gcloud --quiet auth configure-docker eu.gcr.io"
+			id: "auth_gcr"
+			name: "Authenticate to Google Container Registry"
+			uses: "docker/login-action@v1"
+			with: {
+				    registry: "eu.gcr.io"
+				    username: "oauth2accesstoken"
+				    password: "${{ steps.auth_gcp.outputs.access_token }}"
+			}
 		}
 	}
 }


### PR DESCRIPTION
This seems to work: https://github.com/goes-funky/company-api/actions/runs/3197328490 (save for the deployment stabilizing on the incomplete `qa` cluster).

Three cheers to @nhamlh for the CUE lang migration. It's awesome being able to work on these without as much worry.