### PR TITLE
TECH-11304: upgrade github actions to newest version

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -35,7 +35,7 @@ jobs:
           path: build/
           key: ${{ runner.os }}-tools-${{ hashFiles('Makefile', 'makefiles/**') }}
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ inputs.go-version }}
         if: '!steps.tools-cache.outputs.cache-hit'
@@ -56,7 +56,7 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-deps-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ inputs.go-version }}
         if: '!steps.deps-cache.outputs.cache-hit'
@@ -85,7 +85,7 @@ jobs:
         with:
           submodules: true
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ inputs.go-version }}
       - name: Setup tools cache
@@ -117,7 +117,7 @@ jobs:
         with:
           submodules: true
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ inputs.go-version }}
       - name: Setup Go cache

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
@@ -122,7 +122,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
@@ -151,7 +151,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 0
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
@@ -292,7 +292,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -104,7 +104,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools
@@ -138,7 +138,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools
@@ -162,7 +162,7 @@ jobs:
         with:
           path: ~/.skaffold/cache
           key: ${{ runner.os }}-skaffold
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         if: inputs.dist-artifact
         with:
           name: ${{ inputs.dist-artifact }}
@@ -206,7 +206,7 @@ jobs:
       - name: Build
         run: cd ./code && skaffold build --filename=${{ inputs.skaffold-file }} --file-output=build.json
       - name: Archive build reference
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-${{ inputs.skaffold-file }}
           path: ./code/build.json
@@ -231,7 +231,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
@@ -178,7 +178,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
@@ -241,7 +241,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-ref
       - name: Setup Kubernetes tools
@@ -287,7 +287,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-ref
       - name: Setup Kubernetes tools
@@ -315,7 +315,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
@@ -358,7 +358,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
@@ -410,7 +410,7 @@ jobs:
           path: ~/.skaffold/cache
           key: ${{ runner.os }}-skaffold
       - name: Download artifact
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v3
         if: inputs.dist-artifact
         with:
           name: ${{ inputs.dist-artifact }}
@@ -469,7 +469,7 @@ jobs:
         run: cd ./code && skaffold build --file-output=build.json
       - name: Archive build reference
         if: '!inputs.skip-build'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-ref
           path: ./code/build.json
@@ -499,7 +499,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-ref
       - name: Setup Kubernetes tools

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -99,7 +99,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools
@@ -133,7 +133,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools
@@ -157,7 +157,7 @@ jobs:
         with:
           path: ~/.skaffold/cache
           key: ${{ runner.os }}-skaffold
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         if: inputs.dist-artifact
         with:
           name: ${{ inputs.dist-artifact }}
@@ -201,7 +201,7 @@ jobs:
       - name: Build
         run: cd ./code && skaffold build --filename=${{ inputs.skaffold-file }} --file-output=build.json
       - name: Archive build reference
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-${{ inputs.skaffold-file }}
           path: ./code/build.json
@@ -226,7 +226,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools

--- a/pkg/common/deploy-integration.cue
+++ b/pkg/common/deploy-integration.cue
@@ -168,7 +168,7 @@ import "list"
 				},
 				{
 					name: "Download artifact"
-					uses: "actions/download-artifact@master"
+					uses: "actions/download-artifact@v3"
 					if:   "inputs.dist-artifact"
 					with: {
 						name: "${{ inputs.dist-artifact }}"
@@ -215,7 +215,7 @@ import "list"
 				{
 					name: "Archive build reference"
 					if:   "!inputs.skip-build"
-					uses: "actions/upload-artifact@v2"
+					uses: "actions/upload-artifact@v3"
 					with: {
 						name: "build-ref"
 						path: "./code/build.json"
@@ -298,7 +298,7 @@ import "list"
 		#with.gke.step,
 		{
 			name: "Download build reference"
-			uses: "actions/download-artifact@v2"
+			uses: "actions/download-artifact@v3"
 			with: {
 				name: "build-ref"
 			}
@@ -340,7 +340,7 @@ import "list"
 #step_setup_python: {
 	name: "Setup python"
 	id:   "setup-python"
-	uses: "actions/setup-python@v2"
+	uses: "actions/setup-python@v4"
 	with: "python-version": "${{ inputs.python-version }}"
 }
 

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -99,7 +99,7 @@ import "list"
 			}
 		},
 		{
-			uses: "actions/download-artifact@master"
+			uses: "actions/download-artifact@v3"
 			if:   "inputs.dist-artifact"
 			with: {
 				name: "${{ inputs.dist-artifact }}"
@@ -127,7 +127,7 @@ import "list"
 		},
 		{
 			name: "Archive build reference"
-			uses: "actions/upload-artifact@v2"
+			uses: "actions/upload-artifact@v3"
 			with: {
 				name: "build-${{ inputs.skaffold-file }}"
 				path: "./code/build.json"
@@ -167,7 +167,7 @@ import "list"
 		#with.gke.step,
 		{
 		name: "Download build reference"
-		uses: "actions/download-artifact@v2"
+		uses: "actions/download-artifact@v3"
 		with: {
 			name: "build-${{ inputs.skaffold-file }}"
 		}

--- a/pkg/workflows/build-go.cue
+++ b/pkg/workflows/build-go.cue
@@ -26,7 +26,7 @@ import "github.com/goes-funky/workflows/pkg/common"
 
 #step_setup_go: common.#step & {
 	name: "Setup go"
-	uses: "actions/setup-go@v2"
+	uses: "actions/setup-go@v3"
 	with: "go-version": "${{ inputs.go-version }}"
 }
 
@@ -59,7 +59,7 @@ common.#workflow & {
 				#step_setup_tools_cache,
 				{
 					name: "Setup go"
-					uses: "actions/setup-go@v2"
+					uses: "actions/setup-go@v3"
 					with: "go-version": "${{ inputs.go-version }}"
 					if: "!steps.tools-cache.outputs.cache-hit"
 				},
@@ -77,7 +77,7 @@ common.#workflow & {
 				#step_setup_deps_cache,
 				{
 					name: "Setup go"
-					uses: "actions/setup-go@v2"
+					uses: "actions/setup-go@v3"
 					with: "go-version": "${{ inputs.go-version }}"
 					if: "!steps.deps-cache.outputs.cache-hit"
 				},

--- a/pkg/workflows/build-python.cue
+++ b/pkg/workflows/build-python.cue
@@ -5,7 +5,7 @@ import "github.com/goes-funky/workflows/pkg/common"
 #step_setup_python: common.#step & {
 	name: "Setup python"
 	id:   "setup-python"
-	uses: "actions/setup-python@v2"
+	uses: "actions/setup-python@v4"
 	with: {
 		"python-version": "${{ inputs.python-version }}"
 	}


### PR DESCRIPTION
### Issue

https://app.clickup.com/t/2575789/TECH-11304

### What

Upgrade standard github actions to newest major version to fix the set-output warnings.