### PR TITLE
TECH-11304: bump setup-kube-tools version

### DIFF
--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -108,7 +108,7 @@ jobs:
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}
@@ -142,7 +142,7 @@ jobs:
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}
@@ -194,7 +194,7 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: |-
             skaffold
@@ -235,7 +235,7 @@ jobs:
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -245,7 +245,7 @@ jobs:
         with:
           name: build-ref
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}
@@ -291,7 +291,7 @@ jobs:
         with:
           name: build-ref
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}
@@ -442,7 +442,7 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: |-
             skaffold
@@ -503,7 +503,7 @@ jobs:
         with:
           name: build-ref
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -103,7 +103,7 @@ jobs:
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}
@@ -137,7 +137,7 @@ jobs:
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}
@@ -189,7 +189,7 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: |-
             skaffold
@@ -230,7 +230,7 @@ jobs:
         with:
           name: build-${{ inputs.skaffold-file }}
       - name: Setup Kubernetes tools
-        uses: yokawasa/action-setup-kube-tools@v0.7.1
+        uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: skaffold
           skaffold: ${{ inputs.skaffold }}

--- a/pkg/common/steps.cue
+++ b/pkg/common/steps.cue
@@ -60,7 +60,7 @@ package common
 
 		step: #step & {
 			name: "Setup Kubernetes tools"
-			uses: "yokawasa/action-setup-kube-tools@v0.7.1"
+			uses: "yokawasa/action-setup-kube-tools@v0.9.2"
 			with: {} | *{
 				"setup-tools": """
 					skaffold


### PR DESCRIPTION
### What

Bump setup-kube-tools version to avoid warnings with regards to set-output calls.