### PR TITLE
TECH-11304: bump skip-duplicate-actions version

### DIFF
--- a/.github/workflows/build-php.yaml
+++ b/.github/workflows/build-php.yaml
@@ -32,7 +32,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v4
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           concurrent_skipping: never
           skip_after_successful_duplicate: "true"

--- a/pkg/workflows/build-php.cue
+++ b/pkg/workflows/build-php.cue
@@ -40,7 +40,7 @@ common.#workflow & {
 			outputs: should_skip: "${{ steps.skip_check.outputs.should_skip }}"
 			steps: [{
 				id:   "skip_check"
-				uses: "fkirc/skip-duplicate-actions@v4"
+				uses: "fkirc/skip-duplicate-actions@v5"
 				with: {
 					concurrent_skipping:             "never"
 					skip_after_successful_duplicate: "true"


### PR DESCRIPTION
### What

Bump version, because they fix the set-output deprecation warning in 5.2.0.