### PR TITLE
TECH-12960: Skaffold build short-sha

### DIFF
--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -203,7 +203,14 @@ jobs:
           kubeval: ${{ inputs.kubeval }}
       - name: Configure Skaffold
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
+      - name: Export git build details
+        run: |-
+          CONTAINER_NAME=$(basename -s .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+          SHORT_SHA="$(git rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
       - name: Build
+        env:
+          CONTAINER_NAME: ${{ env.CONTAINER_NAME }}
+          SHORT_SHA: ${{ env.SHORT_SHA }}
         run: cd ./code && skaffold build --filename=${{ inputs.skaffold-file }} --file-output=build.json
       - name: Archive build reference
         uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -205,8 +205,8 @@ jobs:
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
       - name: Export git build details
         run: |-
-          CONTAINER_NAME=$(basename -s .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
-          SHORT_SHA="$(git rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
+          CONTAINER_NAME=$(basename -s -C ./code .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+          SHORT_SHA="$(git -C ./code rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
       - name: Build
         env:
           CONTAINER_NAME: ${{ env.CONTAINER_NAME }}

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -205,7 +205,7 @@ jobs:
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
       - name: Export git build details
         run: |-
-          CONTAINER_NAME=$(basename -s -C ./code .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+          CONTAINER_NAME=$(basename -s ./code/.git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
           SHORT_SHA="$(git -C ./code rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
       - name: Build
         env:

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -205,7 +205,7 @@ jobs:
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
       - name: Export git build details
         run: |-
-          CONTAINER_NAME=$(basename -s ./code/.git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+          CONTAINER_NAME=$(cd ./code && basename -s .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
           SHORT_SHA="$(git -C ./code rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
       - name: Build
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -200,7 +200,7 @@ jobs:
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
       - name: Export git build details
         run: |-
-          CONTAINER_NAME=$(basename -s -C ./code .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+          CONTAINER_NAME=$(basename -s ./code/.git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
           SHORT_SHA="$(git -C ./code rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
       - name: Build
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -198,7 +198,14 @@ jobs:
           kubeval: ${{ inputs.kubeval }}
       - name: Configure Skaffold
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
+      - name: Export git build details
+        run: |-
+          CONTAINER_NAME=$(basename -s .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+          SHORT_SHA="$(git rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
       - name: Build
+        env:
+          CONTAINER_NAME: ${{ env.CONTAINER_NAME }}
+          SHORT_SHA: ${{ env.SHORT_SHA }}
         run: cd ./code && skaffold build --filename=${{ inputs.skaffold-file }} --file-output=build.json
       - name: Archive build reference
         uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -200,8 +200,8 @@ jobs:
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
       - name: Export git build details
         run: |-
-          CONTAINER_NAME=$(basename -s .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
-          SHORT_SHA="$(git rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
+          CONTAINER_NAME=$(basename -s -C ./code .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+          SHORT_SHA="$(git -C ./code rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
       - name: Build
         env:
           CONTAINER_NAME: ${{ env.CONTAINER_NAME }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -200,7 +200,7 @@ jobs:
         run: skaffold config set default-repo "${{ inputs.default-repo }}"
       - name: Export git build details
         run: |-
-          CONTAINER_NAME=$(basename -s ./code/.git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+          CONTAINER_NAME=$(cd ./code && basename -s .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
           SHORT_SHA="$(git -C ./code rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
       - name: Build
         env:

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -124,7 +124,7 @@ import "list"
 		{
 			name: "Export git build details"
 			run: """
-				CONTAINER_NAME=$(basename -s ./code/.git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+				CONTAINER_NAME=$(cd ./code && basename -s .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
 				SHORT_SHA="$(git -C ./code rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
 				"""
 		},

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -122,7 +122,18 @@ import "list"
 			run:  "skaffold config set default-repo \"${{ inputs.default-repo }}\""
 		},
 		{
+			name: "Export git build details"
+			run: """
+				CONTAINER_NAME=$(basename -s .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+				SHORT_SHA="$(git rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
+				"""
+		},
+		{
 			name: "Build"
+			env: {
+				CONTAINER_NAME: "${{ env.CONTAINER_NAME }}"
+				SHORT_SHA:      "${{ env.SHORT_SHA }}"
+			}
 			run:  "cd ./code && skaffold build --filename=${{ inputs.skaffold-file }} --file-output=build.json"
 		},
 		{

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -124,8 +124,8 @@ import "list"
 		{
 			name: "Export git build details"
 			run: """
-				CONTAINER_NAME=$(basename -s .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
-				SHORT_SHA="$(git rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
+				CONTAINER_NAME=$(basename -s -C ./code .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+				SHORT_SHA="$(git -C ./code rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
 				"""
 		},
 		{

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -124,7 +124,7 @@ import "list"
 		{
 			name: "Export git build details"
 			run: """
-				CONTAINER_NAME=$(basename -s -C ./code .git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
+				CONTAINER_NAME=$(basename -s ./code/.git "$(git remote get-url origin)") && echo "CONTAINER_NAME=$CONTAINER_NAME" >> "$GITHUB_ENV"
 				SHORT_SHA="$(git -C ./code rev-parse --short HEAD)" && echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
 				"""
 		},


### PR DESCRIPTION
We currently use the git short sha for the Datadog version number. This pr enables skaffold to access this during the build process so we can inject this via Docker into the built container.