### PR TITLE
TECH-10695: set default timeout for all jobs

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -22,6 +22,7 @@ jobs:
   tools:
     runs-on: ubuntu-latest
     name: Tools
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -45,6 +46,7 @@ jobs:
   deps:
     runs-on: ubuntu-latest
     name: Dependencies
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -78,6 +80,7 @@ jobs:
     name: Check
     env:
       GOLANGCILINT_CONCURRENCY: "4"
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -110,6 +113,7 @@ jobs:
       - deps
     runs-on: ubuntu-latest
     name: Test
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'

--- a/.github/workflows/build-php.yaml
+++ b/.github/workflows/build-php.yaml
@@ -22,6 +22,7 @@ jobs:
   check-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: amannn/action-semantic-pull-request@v4
         env:
@@ -30,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    timeout-minutes: 15
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
@@ -45,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    timeout-minutes: 15
     steps:
       - id: set-matrix
         run: echo "matrix={\"php-version\":[\"8.1\"],\"extensions\":[\"${{ inputs.extensions }}\"],\"database\":[\"${{ inputs.database }}\"]}" >> "$GITHUB_OUTPUT"
@@ -58,6 +61,7 @@ jobs:
     env:
       key: cache-v1-${{ matrix.php-versions }}-${{ matrix.extensions }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
         name: Checkout
@@ -113,6 +117,7 @@ jobs:
     env:
       key: cache-v1-${{ matrix.php-versions }}-${{ matrix.extensions }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
         name: Checkout
@@ -166,6 +171,7 @@ jobs:
       APP_ENV: testing
       key: cache-v1-${{ matrix.php-versions }}-${{ matrix.extensions }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
         name: Checkout

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -75,6 +75,7 @@ jobs:
   deps:
     runs-on: ubuntu-${{ inputs.ubuntu-version }}
     name: Dependencies
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -116,6 +117,7 @@ jobs:
     needs:
       - deps
     runs-on: ubuntu-${{ inputs.ubuntu-version }}
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -145,6 +147,7 @@ jobs:
     needs:
       - deps
     runs-on: ubuntu-${{ inputs.ubuntu-version }}
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -177,6 +180,7 @@ jobs:
     needs:
       - deps
     runs-on: ubuntu-${{ inputs.ubuntu-version }}
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -232,6 +236,7 @@ jobs:
     name: Integration tests
     if: '!inputs.skip-integration-tests'
     runs-on: ubuntu-${{ inputs.ubuntu-version }}
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -286,6 +291,7 @@ jobs:
     needs:
       - deps
     runs-on: ubuntu-${{ inputs.ubuntu-version }}
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -90,6 +90,7 @@ jobs:
     environment: ${{ inputs.development-environment }}
     runs-on: ubuntu-latest
     name: Deploy to development
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -124,6 +125,7 @@ jobs:
     environment: ${{ inputs.production-environment }}
     runs-on: ubuntu-latest
     name: Deploy to production
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -151,6 +153,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build Docker images
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -217,6 +220,7 @@ jobs:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     name: Deploy to environment
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -119,6 +119,7 @@ jobs:
     if: '!inputs.skip-integration-schema-generate && (github.event.ref == format(''refs/heads/{0}'', inputs.development-branch) || startsWith(github.event.ref, ''refs/tags/v''))'
     environment: ${{ inputs.development-environment }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -172,6 +173,7 @@ jobs:
     if: '!inputs.skip-integration-schema-generate && startsWith(github.event.ref, ''refs/tags/v'')'
     environment: ${{ inputs.production-environment }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -222,6 +224,7 @@ jobs:
     if: '!inputs.skip-deploy && (github.event.ref == format(''refs/heads/{0}'', inputs.development-branch) || startsWith(github.event.ref, ''refs/tags/v''))'
     environment: ${{ inputs.development-environment }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -268,6 +271,7 @@ jobs:
     if: '!inputs.skip-deploy && startsWith(github.event.ref, ''refs/tags/v'')'
     environment: ${{ inputs.production-environment }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -309,6 +313,7 @@ jobs:
   deps:
     runs-on: ubuntu-latest
     name: Dependencies
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -352,6 +357,7 @@ jobs:
     if: inputs.environment
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -398,6 +404,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build Docker images
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -480,6 +487,7 @@ jobs:
     if: inputs.environment
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -85,6 +85,7 @@ jobs:
     environment: ${{ inputs.development-environment }}
     runs-on: ubuntu-latest
     name: Deploy to development
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -119,6 +120,7 @@ jobs:
     environment: ${{ inputs.production-environment }}
     runs-on: ubuntu-latest
     name: Deploy to production
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -146,6 +148,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build Docker images
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'
@@ -212,6 +215,7 @@ jobs:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     name: Deploy to environment
+    timeout-minutes: 15
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -14,6 +14,7 @@ jobs:
   create:
     runs-on: ubuntu-latest
     name: Create draft release
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -8,6 +8,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     name: Verify
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/pkg/common/workflow.cue
+++ b/pkg/common/workflow.cue
@@ -64,6 +64,7 @@ package common
 		"max-parallel"?: int
 		matrix?: #string_map | =~ "^\\$\\{\\{.*\\}\\}$"
 	}
+	"timeout-minutes": int | *15
 	steps: [...#step]
 }
 


### PR DESCRIPTION
### What

Set a default timeout of 15minutes for all workflows that can be overwritten in the individual job configs. This might break some things that happen today, but should be easy to remediate once people complain.

The default timeout is at 6h which seems a bit crazy to me.