### PR TITLE
TECH-13067: skaffold cache fixes

### DIFF
--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -164,7 +164,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.skaffold/cache
-          key: ${{ runner.os }}-skaffold
+          key: ${{ runner.os }}-skaffold-${{ github.sha }}
+          restore-keys: |-
+            ${{ runner.os }}-skaffold-${{ github.sha }}
+            ${{ runner.os }}-skaffold
       - uses: actions/download-artifact@v3
         if: inputs.dist-artifact
         with:

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -415,7 +415,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.skaffold/cache
-          key: ${{ runner.os }}-skaffold
+          key: ${{ runner.os }}-skaffold-${{ github.sha }}
+          restore-keys: |-
+            ${{ runner.os }}-skaffold-${{ github.sha }}
+            ${{ runner.os }}-skaffold
       - name: Download artifact
         uses: actions/download-artifact@v3
         if: inputs.dist-artifact

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -159,7 +159,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.skaffold/cache
-          key: ${{ runner.os }}-skaffold
+          key: ${{ runner.os }}-skaffold-${{ github.sha }}
+          restore-keys: |-
+            ${{ runner.os }}-skaffold-${{ github.sha }}
+            ${{ runner.os }}-skaffold
       - uses: actions/download-artifact@v3
         if: inputs.dist-artifact
         with:

--- a/pkg/common/deploy-integration.cue
+++ b/pkg/common/deploy-integration.cue
@@ -158,14 +158,7 @@ import "list"
 						path: "./code"
 					}
 				},
-				{
-					name: "Setup skaffold cache"
-					uses: "actions/cache@v3"
-					with: {
-						path: "~/.skaffold/cache"
-						key:  "${{ runner.os }}-skaffold"
-					}
-				},
+				#with.skaffold_cache.step,
 				{
 					name: "Download artifact"
 					uses: "actions/download-artifact@v3"

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -90,14 +90,7 @@ import "list"
 				path: "./code"
 			}
 		},
-		{
-			name: "Setup skaffold cache"
-			uses: "actions/cache@v3"
-			with: {
-				path: "~/.skaffold/cache"
-				key:  "${{ runner.os }}-skaffold"
-			}
-		},
+		#with.skaffold_cache.step,
 		{
 			uses: "actions/download-artifact@v3"
 			if:   "inputs.dist-artifact"

--- a/pkg/common/steps.cue
+++ b/pkg/common/steps.cue
@@ -148,4 +148,18 @@ package common
     		}
     	}
     }
+    skaffold_cache: {
+        step: #step & {
+            name: "Setup skaffold cache"
+            uses: "actions/cache@v3"
+            with: {
+                path: "~/.skaffold/cache"
+                key:  "${{ runner.os }}-skaffold-${{ github.sha }}"
+                "restore-keys": """
+                    ${{ runner.os }}-skaffold-${{ github.sha }}
+                    ${{ runner.os }}-skaffold
+                    """
+            }
+        }
+    }
 }


### PR DESCRIPTION
The current version of the skaffold cache setup is actually useless as the cache is created on the first action run and is never updated then.
The fix is based on this https://github.com/GoogleContainerTools/skaffold/issues/4842#issuecomment-709423350