### PR TITLE
TECH-12148: remove pre-job on PHP workflows and update google actions to v1

### DIFF
--- a/.github/workflows/build-php.yaml
+++ b/.github/workflows/build-php.yaml
@@ -31,23 +31,9 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  pre-job:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    timeout-minutes: 15
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          concurrent_skipping: never
-          skip_after_successful_duplicate: "true"
-          do_not_skip: '["pull_request", "schedule" ${{ !inputs.skip-duplicate-actions-on-manual-runs && '', "workflow_dispatch"'' || '''' }} ]'
   matrix:
-    needs:
-      - check-pr
-      - pre-job
-    if: ${{ always() && needs.pre-job.outputs.should_skip != 'true' && (needs.check-pr.result == 'success' || needs.check-pr.result == 'skipped') }}
+    needs: [check-pr]
+    if: ${{ always() && (needs.check-pr.result == 'success' || needs.check-pr.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/build-php.yaml
+++ b/.github/workflows/build-php.yaml
@@ -32,7 +32,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   matrix:
-    needs: [check-pr]
+    needs:
+      - check-pr
     if: ${{ always() && (needs.check-pr.result == 'success' || needs.check-pr.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -250,7 +250,7 @@ jobs:
           ssh-private-key: ${{ secrets.ssh-private-key }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-gcr-project-id }}
           credentials_json: ${{ secrets.gcp-gcr-service-account }}

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -101,11 +101,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
-      - uses: google-github-actions/get-gke-credentials@v0.8.0
+      - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
@@ -136,11 +136,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
-      - uses: google-github-actions/get-gke-credentials@v0.8.0
+      - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
@@ -187,7 +187,7 @@ jobs:
           ssh-private-key: ${{ secrets.ssh-private-key }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-gcr-project-id }}
           credentials_json: ${{ secrets.gcp-gcr-service-account }}
@@ -244,11 +244,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
-      - uses: google-github-actions/get-gke-credentials@v0.8.0
+      - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -153,12 +153,12 @@ jobs:
           eval "$GENERATE_SCHEMA_COMMAND"
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
       - name: Upload Integration schema to JSON schema folder
-        uses: google-github-actions/upload-cloud-storage@v0.8.0
+        uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: integrations
           destination: ${{ secrets.json-schema-bucket }}
@@ -207,12 +207,12 @@ jobs:
           eval "$GENERATE_SCHEMA_COMMAND"
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
       - name: Upload Integration schema to JSON schema folder
-        uses: google-github-actions/upload-cloud-storage@v0.8.0
+        uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: integrations
           destination: ${{ secrets.json-schema-bucket }}
@@ -236,11 +236,11 @@ jobs:
           ssh-private-key: ${{ secrets.ssh-private-key }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
-      - uses: google-github-actions/get-gke-credentials@v0.8.0
+      - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
@@ -283,11 +283,11 @@ jobs:
           ssh-private-key: ${{ secrets.ssh-private-key }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
-      - uses: google-github-actions/get-gke-credentials@v0.8.0
+      - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
@@ -391,12 +391,12 @@ jobs:
           eval "$GENERATE_SCHEMA_COMMAND"
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
       - name: Upload Integration schema to JSON schema folder
-        uses: google-github-actions/upload-cloud-storage@v0.8.0
+        uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: integrations
           destination: ${{ secrets.json-schema-bucket }}
@@ -432,7 +432,7 @@ jobs:
           ssh-private-key: ${{ secrets.ssh-private-key }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-gcr-project-id }}
           credentials_json: ${{ secrets.gcp-gcr-service-account }}
@@ -502,11 +502,11 @@ jobs:
           ssh-private-key: ${{ secrets.ssh-private-key }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
-      - uses: google-github-actions/get-gke-credentials@v0.8.0
+      - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -96,11 +96,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
-      - uses: google-github-actions/get-gke-credentials@v0.8.0
+      - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
@@ -131,11 +131,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
-      - uses: google-github-actions/get-gke-credentials@v0.8.0
+      - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference
@@ -182,7 +182,7 @@ jobs:
           ssh-private-key: ${{ secrets.ssh-private-key }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-gcr-project-id }}
           credentials_json: ${{ secrets.gcp-gcr-service-account }}
@@ -239,11 +239,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Authenticate to Google Cloud
         id: auth_gcp
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
-      - uses: google-github-actions/get-gke-credentials@v0.8.0
+      - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
       - name: Download build reference

--- a/pkg/common/deploy-integration.cue
+++ b/pkg/common/deploy-integration.cue
@@ -269,7 +269,7 @@ import "list"
 				{
 					name: "Upload Integration schema to JSON schema folder"
 					//pinning version till resolved https://github.com/google-github-actions/upload-cloud-storage/issues/248
-					uses: "google-github-actions/upload-cloud-storage@v0.8.0"
+					uses: "google-github-actions/upload-cloud-storage@v1"
 					with: {
 						path:        "integrations"
 						destination: "${{ secrets.json-schema-bucket }}"

--- a/pkg/common/steps.cue
+++ b/pkg/common/steps.cue
@@ -95,7 +95,7 @@ package common
 		step: #step & {
 			id: "auth_gcp"
 			name: "Authenticate to Google Cloud"
-			uses: "google-github-actions/auth@v0"
+			uses: "google-github-actions/auth@v1"
 			with: {} | *{
 				project_id:                 "${{ secrets.gcp-project-id }}"
 				credentials_json:           "${{ secrets.gcp-service-account }}"
@@ -116,7 +116,7 @@ package common
 		}
 
 		step: #step & {
-			uses: "google-github-actions/get-gke-credentials@v0.8.0"
+			uses: "google-github-actions/get-gke-credentials@v1"
 			with: {
 				cluster_name: "${{ secrets.gke-cluster }}"
 			}

--- a/pkg/workflows/build-php.cue
+++ b/pkg/workflows/build-php.cue
@@ -41,22 +41,9 @@ common.#workflow & {
 				env: GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 			}]
 		}
-		"pre-job": {
-			outputs: should_skip: "${{ steps.skip_check.outputs.should_skip }}"
-			steps: [{
-				id:   "skip_check"
-				uses: "fkirc/skip-duplicate-actions@v5"
-				with: {
-					concurrent_skipping:             "never"
-					skip_after_successful_duplicate: "true"
-					//paths_ignore: '["**/README.md", "**/docs/**"]'
-					do_not_skip: "[\"pull_request\", \"schedule\" ${{ !inputs.skip-duplicate-actions-on-manual-runs && ', \"workflow_dispatch\"' || '' }} ]"
-				}
-			}]
-		}
 		matrix: {
-			needs: ["check-pr", "pre-job"]
-			if: "${{ always() && needs.pre-job.outputs.should_skip != 'true' && (needs.check-pr.result == 'success' || needs.check-pr.result == 'skipped') }}"
+			needs: ["check-pr"]
+			if: "${{ always() && (needs.check-pr.result == 'success' || needs.check-pr.result == 'skipped') }}"
 			outputs: matrix: "${{ steps.set-matrix.outputs.matrix }}"
 			steps: [{
 				id: "set-matrix"


### PR DESCRIPTION
### Issue

https://app.clickup.com/t/2575789/TECH-12148

### What

- In specific cases the pre-job skips existing runs for php. IMO it's not necessary and it seems to skip _later_ runs. So overall, we should be able to remove it. Also, the action uses the deprecated `set-output` command.
- Upgrade google-github-actions to v1