### PR TITLE
TECH-13307: Allow deploy to prod from main

### DIFF
--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -119,7 +119,7 @@ jobs:
           skaffold: ${{ inputs.skaffold }}
       - name: Deploy
         env:
-          SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
+          SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment) && 'prod' || 'nonprod' }}
         run: skaffold deploy --filename=${{ inputs.skaffold-file }} --force --build-artifacts=build.json
   deploy-production:
     needs:
@@ -262,5 +262,5 @@ jobs:
           skaffold: ${{ inputs.skaffold }}
       - name: Deploy
         env:
-          SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
+          SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment) && 'prod' || 'nonprod' }}
         run: skaffold deploy --filename=${{ inputs.skaffold-file }} --force --build-artifacts=build.json

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -114,7 +114,7 @@ jobs:
           skaffold: ${{ inputs.skaffold }}
       - name: Deploy
         env:
-          SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
+          SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment) && 'prod' || 'nonprod' }}
         run: skaffold deploy --filename=${{ inputs.skaffold-file }} --force --build-artifacts=build.json
   deploy-production:
     needs:
@@ -257,5 +257,5 @@ jobs:
           skaffold: ${{ inputs.skaffold }}
       - name: Deploy
         env:
-          SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}
+          SKAFFOLD_PROFILE: ${{ (inputs.environment == inputs.production-environment) && 'prod' || 'nonprod' }}
         run: skaffold deploy --filename=${{ inputs.skaffold-file }} --force --build-artifacts=build.json

--- a/pkg/common/deploy.cue
+++ b/pkg/common/deploy.cue
@@ -157,7 +157,7 @@ import "list"
 				{
 					name: "Deploy"
 					env: {
-						SKAFFOLD_PROFILE: "${{ (inputs.environment == inputs.production-environment && github.event.ref != format('refs/heads/{0}', inputs.development-branch)) && 'prod' || 'nonprod' }}"
+						SKAFFOLD_PROFILE: "${{ (inputs.environment == inputs.production-environment) && 'prod' || 'nonprod' }}"
 					}
 					run: "skaffold deploy --filename=${{ inputs.skaffold-file }} --force --build-artifacts=build.json"
 				},


### PR DESCRIPTION
No longer attempt to block deploys from the develop branches from going to prod. Now any branch can go to prod.
Previous code was using wrong skaffold profile on prod deploys