### PR TITLE
TECH-13728: fix missing GITHUB_SHA build arg

### DIFF
--- a/scripts/docker-buildx
+++ b/scripts/docker-buildx
@@ -13,6 +13,7 @@ declare -a _build_args=(
     '--build-arg' "CONTAINER_NAME=${CONTAINER_NAME}"
     '--build-arg' "COMMIT_SHA=${COMMIT_SHA}"
     '--build-arg' "IMAGE_NAME=${IMAGE_NAME}"
+    '--build-arg' "GITHUB_SHA=${GITHUB_SHA}"
 )
 
 if [[ "${PUSH_IMAGE}" == "true" ]]; then


### PR DESCRIPTION
This should fix the issue experienced on https://github.com/goes-funky/low-code-api/actions/runs/3827910890