### PR TITLE
Fetch submodules in Python project builds

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -8,7 +8,7 @@ name: Build Go
         default: false
       with-submodules:
         type: boolean
-        description: Whether to skip checkout
+        description: Whether to fetch git submodules
         default: true
       is-repo-public:
         type: boolean

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -2,18 +2,22 @@ name: Build Go
 "on":
   workflow_call:
     inputs:
-      go-version:
-        type: string
-        description: Go version
-        default: "1.17"
       skip-checkout:
         type: boolean
         description: Whether to skip checkout
         default: false
+      with-submodules:
+        type: boolean
+        description: Whether to skip checkout
+        default: true
       is-repo-public:
         type: boolean
         description: Whether to skip ssh agent configuration
         default: false
+      go-version:
+        type: string
+        description: Go version
+        default: "1.17"
     secrets:
       ssh-private-key:
         description: SSH private key used to authenticate to GitHub with, in order to fetch private dependencies
@@ -28,7 +32,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup tools cache
         id: tools-cache
         uses: actions/cache@v3
@@ -51,6 +55,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup Go cache
         id: deps-cache
         uses: actions/cache@v3
@@ -86,7 +92,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup go
         uses: actions/setup-go@v3
         with:
@@ -119,7 +125,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -95,8 +95,6 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3
@@ -228,7 +226,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3
@@ -292,7 +289,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3
@@ -351,8 +347,6 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -59,6 +59,10 @@ name: Build Python
         type: boolean
         description: Whether to skip sonarcloud scans
         default: true
+      with-submodules:
+        type: boolean
+        description: Whether to skip checkout
+        default: false
     secrets:
       gcp-gcr-project-id:
         description: GCP GCR Project ID. Required for integration_tests.
@@ -95,6 +99,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3
@@ -142,6 +148,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3
@@ -178,6 +186,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
         with:
+          submodules: ${{ inputs.with-submodules }}
           fetch-depth: 0
       - name: Download artifact
         if: inputs.project-artifact
@@ -225,6 +234,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
         with:
+          submodules: ${{ inputs.with-submodules }}
           fetch-depth: 0
       - name: Download artifact
         if: inputs.project-artifact
@@ -288,6 +298,7 @@ jobs:
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
         with:
+          submodules: ${{ inputs.with-submodules }}
           fetch-depth: 0
       - name: Download artifact
         if: inputs.project-artifact
@@ -347,6 +358,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -95,6 +95,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3
@@ -226,6 +228,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          submodules: true
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3
@@ -289,6 +292,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          submodules: true
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3
@@ -347,6 +351,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Download artifact
         if: inputs.project-artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -61,7 +61,7 @@ name: Build Python
         default: true
       with-submodules:
         type: boolean
-        description: Whether to skip checkout
+        description: Whether to fetch git submodules
         default: false
     secrets:
       gcp-gcr-project-id:

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -64,7 +64,7 @@ name: Deploy
         description: Setup skaffold cache before build
       with-submodules:
         type: boolean
-        description: Whether to skip checkout
+        description: Whether to fetch git submodules
         default: false
       kubeval:
         type: string

--- a/.github/workflows/deploy-git-flow.yaml
+++ b/.github/workflows/deploy-git-flow.yaml
@@ -62,6 +62,10 @@ name: Deploy
         required: false
         default: true
         description: Setup skaffold cache before build
+      with-submodules:
+        type: boolean
+        description: Whether to skip checkout
+        default: false
       kubeval:
         type: string
         description: Kubeval version
@@ -108,6 +112,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
         uses: google-github-actions/auth@v1
@@ -141,6 +147,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
         uses: google-github-actions/auth@v1
@@ -274,6 +282,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
         uses: google-github-actions/auth@v1

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -84,6 +84,10 @@ name: Deploy Integration
         required: false
         default: false
         description: Setup skaffold cache before build
+      with-submodules:
+        type: boolean
+        description: Whether to skip checkout
+        default: false
       kubeval:
         type: string
         description: Kubeval version
@@ -129,6 +133,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup python
         id: setup-python
         uses: actions/setup-python@v4
@@ -183,6 +189,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup python
         id: setup-python
         uses: actions/setup-python@v4
@@ -234,6 +242,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup SSH Agent
         if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.7.0
@@ -281,6 +291,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup SSH Agent
         if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.7.0
@@ -323,6 +335,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup python
         id: setup-python
         uses: actions/setup-python@v4
@@ -367,6 +381,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup python
         id: setup-python
         uses: actions/setup-python@v4
@@ -525,6 +541,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Setup SSH Agent
         if: '!inputs.is-repo-public'
         uses: webfactory/ssh-agent@v0.7.0

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -86,7 +86,7 @@ name: Deploy Integration
         description: Setup skaffold cache before build
       with-submodules:
         type: boolean
-        description: Whether to skip checkout
+        description: Whether to fetch git submodules
         default: false
       kubeval:
         type: string

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,6 +62,10 @@ name: Deploy
         required: false
         default: true
         description: Setup skaffold cache before build
+      with-submodules:
+        type: boolean
+        description: Whether to skip checkout
+        default: false
       kubeval:
         type: string
         description: Kubeval version
@@ -103,6 +107,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
         uses: google-github-actions/auth@v1
@@ -136,6 +142,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
         uses: google-github-actions/auth@v1
@@ -269,6 +277,8 @@ jobs:
       - name: Checkout
         if: '!inputs.skip-checkout'
         uses: actions/checkout@v3
+        with:
+          submodules: ${{ inputs.with-submodules }}
       - name: Authenticate to Google Cloud
         id: auth_gcp
         uses: google-github-actions/auth@v1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,7 +64,7 @@ name: Deploy
         description: Setup skaffold cache before build
       with-submodules:
         type: boolean
-        description: Whether to skip checkout
+        description: Whether to fetch git submodules
         default: false
       kubeval:
         type: string

--- a/.github/workflows/flux-build.yaml
+++ b/.github/workflows/flux-build.yaml
@@ -26,6 +26,10 @@ name: Flux Skaffold Build
         type: string
         description: Docker file to use
         default: Dockerfile
+      with-submodules:
+        type: boolean
+        description: Whether to skip checkout
+        default: false
     secrets:
       gcp-project-id:
         description: GCP Project ID of the artifact repo

--- a/.github/workflows/flux-build.yaml
+++ b/.github/workflows/flux-build.yaml
@@ -28,7 +28,7 @@ name: Flux Skaffold Build
         default: Dockerfile
       with-submodules:
         type: boolean
-        description: Whether to skip checkout
+        description: Whether to fetch git submodules
         default: false
     secrets:
       gcp-project-id:

--- a/pkg/common/steps.cue
+++ b/pkg/common/steps.cue
@@ -10,7 +10,7 @@ package common
             }
             "with-submodules": {
                 type:        "boolean"
-                description: "Whether to skip checkout"
+                description: "Whether to fetch git submodules"
                 default:     false
             }
         }

--- a/pkg/common/steps.cue
+++ b/pkg/common/steps.cue
@@ -8,12 +8,20 @@ package common
                 description: "Whether to skip checkout"
                 default:     false
             }
+            "with-submodules": {
+                type:        "boolean"
+                description: "Whether to skip checkout"
+                default:     false
+            }
         }
 
         step: #step & {
             name: "Checkout"
             if:   "!inputs.skip-checkout"
             uses: "actions/checkout@v3"
+            with: {
+                "submodules": "${{ inputs.with-submodules }}"
+            }
         }
     }
 

--- a/pkg/workflows/build-go.cue
+++ b/pkg/workflows/build-go.cue
@@ -42,7 +42,7 @@ common.#workflow & {
 				}
 				"with-submodules": {
 					type:        "boolean"
-					description: "Whether to skip checkout"
+					description: "Whether to fetch git submodules"
 					default:     true
 				}
                 common.#with.ssh_agent.inputs

--- a/pkg/workflows/build-go.cue
+++ b/pkg/workflows/build-go.cue
@@ -35,7 +35,16 @@ common.#workflow & {
     on: {
         workflow_call: {
             inputs: {
-                common.#with.checkout.inputs
+            	"skip-checkout": {
+					type:        "boolean"
+					description: "Whether to skip checkout"
+					default:     false
+				}
+				"with-submodules": {
+					type:        "boolean"
+					description: "Whether to skip checkout"
+					default:     true
+				}
                 common.#with.ssh_agent.inputs
                 "go-version": {
                     type:        "string"
@@ -53,9 +62,7 @@ common.#workflow & {
         tools: {
             name: "Tools"
             steps: [
-                common.#with.checkout.step & {
-                    with: submodules: true
-                },
+                common.#with.checkout.step,
                 #step_setup_tools_cache,
                 {
                     name: "Setup go"
@@ -98,9 +105,7 @@ common.#workflow & {
             name: "Check"
             env: GOLANGCILINT_CONCURRENCY: "4"
             steps: [
-                common.#with.checkout.step & {
-                    with: submodules: true
-                },
+                common.#with.checkout.step,
                 #step_setup_go,
                 #step_setup_tools_cache,
                 #step_setup_deps_cache,
@@ -118,9 +123,7 @@ common.#workflow & {
             needs: ["tools", "deps"]
             name: "Test"
             steps: [
-                common.#with.checkout.step & {
-                    with: submodules: true
-                },
+                common.#with.checkout.step,
                 #step_setup_go,
                 #step_setup_deps_cache,
                 {

--- a/pkg/workflows/build-python.cue
+++ b/pkg/workflows/build-python.cue
@@ -135,11 +135,7 @@ common.#workflow & {
             needs: ["pre-job"]
             if: "needs.pre-job.outputs.should_skip != 'true'"
             steps: [
-                common.#with.checkout.step & {
-                    with: {
-                        "submodules": true
-                    }
-                },
+                common.#with.checkout.step,
                 common.#with.load_artifact.step,
                 #step_setup_python,
                 #step_setup_deps_cache,
@@ -219,7 +215,6 @@ common.#workflow & {
                 common.#with.checkout.step & {
                     with: {
                         "fetch-depth": 0
-                        "submodules": true
                     }
                 },
                 common.#with.load_artifact.step,
@@ -278,7 +273,6 @@ common.#workflow & {
                 common.#with.checkout.step & {
                     with: {
                        "fetch-depth": 0
-                       "submodules": true
                     }
                 },
                 common.#with.load_artifact.step,
@@ -328,11 +322,7 @@ common.#workflow & {
             needs: ["deps"]
             "runs-on": "ubuntu-${{ inputs.ubuntu-version }}"
             steps: [
-                common.#with.checkout.step & {
-                    with: {
-                        "submodules": true
-                    }
-                },
+                common.#with.checkout.step,
                 common.#with.load_artifact.step,
                 #step_setup_python,
                 #step_setup_deps_cache,

--- a/pkg/workflows/build-python.cue
+++ b/pkg/workflows/build-python.cue
@@ -135,7 +135,11 @@ common.#workflow & {
             needs: ["pre-job"]
             if: "needs.pre-job.outputs.should_skip != 'true'"
             steps: [
-                common.#with.checkout.step,
+                common.#with.checkout.step & {
+                    with: {
+                        "submodules": true
+                    }
+                },
                 common.#with.load_artifact.step,
                 #step_setup_python,
                 #step_setup_deps_cache,
@@ -215,6 +219,7 @@ common.#workflow & {
                 common.#with.checkout.step & {
                     with: {
                         "fetch-depth": 0
+                        "submodules": true
                     }
                 },
                 common.#with.load_artifact.step,
@@ -273,6 +278,7 @@ common.#workflow & {
                 common.#with.checkout.step & {
                     with: {
                        "fetch-depth": 0
+                       "submodules": true
                     }
                 },
                 common.#with.load_artifact.step,
@@ -322,7 +328,11 @@ common.#workflow & {
             needs: ["deps"]
             "runs-on": "ubuntu-${{ inputs.ubuntu-version }}"
             steps: [
-                common.#with.checkout.step,
+                common.#with.checkout.step & {
+                    with: {
+                        "submodules": true
+                    }
+                },
                 common.#with.load_artifact.step,
                 #step_setup_python,
                 #step_setup_deps_cache,


### PR DESCRIPTION
In https://github.com/goes-funky/dbt-functions/pull/27, we would like to be able to include dbt-utils as a pre-installed package available to dbt projects. @ronozoro proposed to add it as a git submodule, which I agree is a clean way to do it, and better than committing the dbt-utils files directly to the repo. However, our Python build action does not currently fetch submodules (unlike our [Go build actions](https://github.com/goes-funky/workflows/blob/master/.github/workflows/build-go.yaml#L31)). This PR enables it for Python as well.