### PR TITLE
TECH-13724: increase flux build timeout

### DIFF
--- a/.github/workflows/flux-build.yaml
+++ b/.github/workflows/flux-build.yaml
@@ -40,7 +40,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build Docker images
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout
         if: '!inputs.skip-checkout'

--- a/.github/workflows/flux-build.yaml
+++ b/.github/workflows/flux-build.yaml
@@ -80,13 +80,6 @@ jobs:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
           token_format: access_token
-      - name: Authenticate to Google Container Registry
-        id: auth_gcr
-        uses: docker/login-action@v2
-        with:
-          registry: eu.gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Authenticate to Google Artifact Registry
         id: auth_docker_pkg_dev
         uses: docker/login-action@v2

--- a/.github/workflows/flux-build.yaml
+++ b/.github/workflows/flux-build.yaml
@@ -80,6 +80,13 @@ jobs:
           project_id: ${{ secrets.gcp-project-id }}
           credentials_json: ${{ secrets.gcp-service-account }}
           token_format: access_token
+      - name: Authenticate to Google Container Registry
+        id: auth_gcr
+        uses: docker/login-action@v2
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth_gcp.outputs.access_token }}
       - name: Authenticate to Google Artifact Registry
         id: auth_docker_pkg_dev
         uses: docker/login-action@v2

--- a/pkg/common/flux-build.cue
+++ b/pkg/common/flux-build.cue
@@ -38,7 +38,7 @@ package common
 
 #job_flux_build: #job & {
     name: "Build Docker images"
-    "timeout-minutes": 10
+    "timeout-minutes": 20
     steps: [
         {
             name: "Checkout"
@@ -67,7 +67,6 @@ package common
                 token_format:     "access_token"
             }
         },
-        #with.docker_auth.step,
         #with.docker_artifacts_auth.step,
         #with.flux_tools.step,
         {

--- a/pkg/common/flux-build.cue
+++ b/pkg/common/flux-build.cue
@@ -67,6 +67,7 @@ package common
                 token_format:     "access_token"
             }
         },
+        #with.docker_auth.step,
         #with.docker_artifacts_auth.step,
         #with.flux_tools.step,
         {


### PR DESCRIPTION
### What

Allow GCR login with flux builds. This exception is only relevant for the modeling-api today.