### PR TITLE
SRE-415: push integrations to Artifact Registry

### DIFF
--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -258,6 +258,13 @@ jobs:
           service_account: ${{ secrets.gcp-service-account }}
           workload_identity_provider: ${{ secrets.gcp-workload-identity-provider }}
           token_format: access_token
+      - name: Authenticate to Google Artifact Registry
+        id: auth_docker_pkg_dev
+        uses: docker/login-action@v2
+        with:
+          registry: europe-west3-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth_gcp.outputs.access_token }}
       - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -308,6 +315,13 @@ jobs:
           service_account: ${{ secrets.gcp-service-account }}
           workload_identity_provider: ${{ secrets.gcp-workload-identity-provider }}
           token_format: access_token
+      - name: Authenticate to Google Artifact Registry
+        id: auth_docker_pkg_dev
+        uses: docker/login-action@v2
+        with:
+          registry: europe-west3-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth_gcp.outputs.access_token }}
       - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}
@@ -560,6 +574,13 @@ jobs:
           service_account: ${{ secrets.gcp-service-account }}
           workload_identity_provider: ${{ secrets.gcp-workload-identity-provider }}
           token_format: access_token
+      - name: Authenticate to Google Artifact Registry
+        id: auth_docker_pkg_dev
+        uses: docker/login-action@v2
+        with:
+          registry: europe-west3-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth_gcp.outputs.access_token }}
       - uses: google-github-actions/get-gke-credentials@v1
         with:
           cluster_name: ${{ secrets.gke-cluster }}

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -19,7 +19,7 @@ name: Deploy Integration
       default-repo:
         type: string
         description: Default artifact repository
-        default: eu.gcr.io/y42-artifacts-ea47981a
+        default: europe-west3-docker.pkg.dev/y42-artifacts-ea47981a/main
         required: false
       dist-artifact:
         type: string

--- a/pkg/common/deploy-integration.cue
+++ b/pkg/common/deploy-integration.cue
@@ -303,6 +303,7 @@ import "list"
         #with.checkout.step,
         #with.ssh_agent.step,
         #with.gcloud.step,
+        #with.docker_artifacts_auth.step,
         #with.gke.step,
         {
             name: "Download build reference"

--- a/pkg/common/deploy-integration.cue
+++ b/pkg/common/deploy-integration.cue
@@ -29,7 +29,7 @@ import "list"
                 "default-repo": {
                     type:        "string"
                     description: "Default artifact repository"
-                    default:     "eu.gcr.io/y42-artifacts-ea47981a"
+                    default:     "europe-west3-docker.pkg.dev/y42-artifacts-ea47981a/main"
                     required:    false
                 }
                 "dist-artifact": {


### PR DESCRIPTION
Container Registry in addition to (presumably, but confirmed by GCP
marketing copy and our hunches while looking at the billing console)
being the less economical option, is also being deprecated.

Migrate the integrations to the new Artifact Registry.

This won't affect v1 - those integrations build via Cloud Build, into
the `datos-tech` project.
