### PR TITLE
feat: diff_poetry add explicit permission issues write

### DIFF
--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -445,6 +445,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-${{ inputs.ubuntu-version }}
     timeout-minutes: 15
+    permissions:
+      issues: write
     steps:
       - name: Diff poetry.lock
         uses: goes-funky/diff-poetry-lock@main

--- a/pkg/common/workflow.cue
+++ b/pkg/common/workflow.cue
@@ -66,6 +66,7 @@ package common
     }
     "timeout-minutes": int | *15
     steps: [...#step]
+    permissions?: [string]: string
 }
 
 #step: {

--- a/pkg/workflows/build-python.cue
+++ b/pkg/workflows/build-python.cue
@@ -351,6 +351,9 @@ common.#workflow & {
             name: "Diff Poetry lockfile"
             if: "${{ github.event_name == 'pull_request' }}"
             "runs-on": "ubuntu-${{ inputs.ubuntu-version }}"
+            permissions: {
+                issues: "write"
+            }
             steps: [
                 {
                     name: "Diff poetry.lock"


### PR DESCRIPTION
This PR _attempts_ to add explicit permission to the `diff_poetry`. The assigned `issues: write` permission is the same as the default permission. Dependabot requires these permissions to be set explicitly. Otherwise, tests on dependabot PRs will always fail when trying to post the PR comment with the version differences.

FYI: PR comments are technically _just_ issue comments.

> By default, GitHub Actions workflows triggered by Dependabot get a GITHUB_TOKEN with read-only permissions. You can use the permissions key in your workflow to increase the access for the token.

[https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-gith[…]en-permissions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions)

Here is an example of a failing dependabot check: https://github.com/goes-funky/y42-quart-common/actions/runs/8363932727/job/23274676387