### PR TITLE
chore: move node16 actions to node20 version

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -35,7 +35,7 @@ jobs:
           submodules: ${{ inputs.with-submodules }}
       - name: Setup tools cache
         id: tools-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: build/
           key: ${{ runner.os }}-tools-${{ hashFiles('Makefile', 'makefiles/**') }}
@@ -59,7 +59,7 @@ jobs:
           submodules: ${{ inputs.with-submodules }}
       - name: Setup Go cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-deps-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
@@ -99,13 +99,13 @@ jobs:
           go-version: ${{ inputs.go-version }}
       - name: Setup tools cache
         id: tools-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: build/
           key: ${{ runner.os }}-tools-${{ hashFiles('Makefile', 'makefiles/**') }}
       - name: Setup Go cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-deps-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
@@ -132,7 +132,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
       - name: Setup Go cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-deps-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/build-php.yaml
+++ b/.github/workflows/build-php.yaml
@@ -77,7 +77,7 @@ jobs:
           extensions: ${{ matrix.extensions }}
           key: ${{ env.key }}
       - name: Cache extensions
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.extcache.outputs.dir }}
           key: ${{ steps.extcache.outputs.key }}
@@ -97,7 +97,7 @@ jobs:
         run: composer validate
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -131,7 +131,7 @@ jobs:
           extensions: ${{ matrix.extensions }}
           key: ${{ env.key }}
       - name: Cache extensions
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.extcache.outputs.dir }}
           key: ${{ steps.extcache.outputs.key }}
@@ -154,7 +154,7 @@ jobs:
           ssh-private-key: ${{ secrets.ssh-private-key }}
       - name: Composer packages from cache
         id: restore-composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -164,7 +164,7 @@ jobs:
         if: steps.restore-composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress --no-suggest
       - name: PHPStan cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/phpstan
           key: ${{ runner.os }}-phpstan-${{ github.sha }}
@@ -172,7 +172,7 @@ jobs:
             ${{ runner.os }}-phpstan-${{ github.sha }}
             ${{ runner.os }}-phpstan
       - name: Psalm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/psalm
           key: ${{ runner.os }}-psalm-${{ github.sha }}
@@ -219,7 +219,7 @@ jobs:
           extensions: ${{ matrix.extensions }}
           key: ${{ env.key }}
       - name: Cache extensions
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.extcache.outputs.dir }}
           key: ${{ steps.extcache.outputs.key }}
@@ -233,7 +233,7 @@ jobs:
           extensions: ${{ matrix.extensions }}
       - name: Composer packages from cache
         id: restore-composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -108,12 +108,12 @@ jobs:
           name: ${{ inputs.project-artifact }}
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv/
           key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -157,12 +157,12 @@ jobs:
           name: ${{ inputs.project-artifact }}
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv/
           key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -216,12 +216,12 @@ jobs:
           extra_args: --only-verified
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv/
           key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -271,12 +271,12 @@ jobs:
           name: ${{ inputs.project-artifact }}
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv/
           key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -409,12 +409,12 @@ jobs:
           name: ${{ inputs.project-artifact }}
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv/
           key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -137,12 +137,12 @@ jobs:
           submodules: ${{ inputs.with-submodules }}
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv/
           key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -194,12 +194,12 @@ jobs:
           submodules: ${{ inputs.with-submodules }}
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv/
           key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -357,12 +357,12 @@ jobs:
           submodules: ${{ inputs.with-submodules }}
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv/
           key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -403,12 +403,12 @@ jobs:
           submodules: ${{ inputs.with-submodules }}
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv/
           key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -474,7 +474,7 @@ jobs:
         run: 'cp ./code/skaffold.yaml . && yq -i ''del(.build.local) | del(.build.artifacts.[].docker) | del(.build.artifacts.[].sync.*) | .build.artifacts.[] *= {"custom": {"buildCommand": "../docker-buildx", "dependencies": {"dockerfile": {"path": "Dockerfile"}}}}'' skaffold.yaml'
       - name: Setup skaffold cache
         if: inputs.use-skaffold-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.skaffold/cache
           key: ${{ runner.os }}-skaffold-${{ github.sha }}

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup tools cache
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: bin
           key: ${{ runner.os }}-tools-${{ hashFiles('Makefile') }}

--- a/pkg/common/deploy-integration.cue
+++ b/pkg/common/deploy-integration.cue
@@ -349,7 +349,7 @@ import "list"
 #step_setup_python: {
     name: "Setup python"
     id:   "setup-python"
-    uses: "actions/setup-python@v4"
+    uses: "actions/setup-python@v5"
     with: "python-version": "${{ inputs.python-version }}"
 }
 
@@ -366,7 +366,7 @@ import "list"
 #step_setup_deps_cache: {
     name: "Setup cache"
     id:   "deps-cache"
-    uses: "actions/cache@v3"
+    uses: "actions/cache@v4"
     with: {
         path: ".venv/"
         key:  "${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}"

--- a/pkg/common/steps.cue
+++ b/pkg/common/steps.cue
@@ -235,7 +235,7 @@ package common
         step: #step & {
             name: "Setup skaffold cache"
             if:  "inputs.use-skaffold-cache"
-            uses: "actions/cache@v3"
+            uses: "actions/cache@v4"
             with: {
                 path: "~/.skaffold/cache"
                 key:  "${{ runner.os }}-skaffold-${{ github.sha }}"

--- a/pkg/workflows/build-go.cue
+++ b/pkg/workflows/build-go.cue
@@ -5,7 +5,7 @@ import "github.com/goes-funky/workflows/pkg/common"
 #step_setup_tools_cache: common.#step & {
     name: "Setup tools cache"
     id:   "tools-cache"
-    uses: "actions/cache@v3"
+    uses: "actions/cache@v4"
     with: {
         path: "build/"
         key:  "${{ runner.os }}-tools-${{ hashFiles('Makefile', 'makefiles/**') }}"
@@ -16,7 +16,7 @@ import "github.com/goes-funky/workflows/pkg/common"
 #step_setup_deps_cache: common.#step & {
     name: "Setup Go cache"
     id:   "deps-cache"
-    uses: "actions/cache@v3"
+    uses: "actions/cache@v4"
     with: {
         path: "~/go/pkg/mod"
         key:  "${{ runner.os }}-deps-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}"

--- a/pkg/workflows/build-php.cue
+++ b/pkg/workflows/build-php.cue
@@ -86,7 +86,7 @@ common.#workflow & {
                 }
             }, {
                 name: "Cache extensions"
-                uses: "actions/cache@v3"
+                uses: "actions/cache@v4"
                 with: {
                     path:           "${{ steps.extcache.outputs.dir }}"
                     key:            "${{ steps.extcache.outputs.key }}"
@@ -111,7 +111,7 @@ common.#workflow & {
             }, {
                 name: "Cache Composer packages"
                 id:   "composer-cache"
-                uses: "actions/cache@v3"
+                uses: "actions/cache@v4"
                 with: {
                     path: "vendor"
                     key:  "${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}"
@@ -152,7 +152,7 @@ common.#workflow & {
                 }
             }, {
                 name: "Cache extensions"
-                uses: "actions/cache@v3"
+                uses: "actions/cache@v4"
                 with: {
                     path:           "${{ steps.extcache.outputs.dir }}"
                     key:            "${{ steps.extcache.outputs.key }}"
@@ -174,7 +174,7 @@ common.#workflow & {
            }, {
                 name: "Composer packages from cache"
                 id:   "restore-composer-cache"
-                uses: "actions/cache@v3"
+                uses: "actions/cache@v4"
                 with: {
                     path: "vendor"
                     key:  "${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}"
@@ -189,7 +189,7 @@ common.#workflow & {
                 run:  "composer install --prefer-dist --no-progress --no-suggest"
             }, {
                 name: "PHPStan cache"
-                uses: "actions/cache@v3"
+                uses: "actions/cache@v4"
                 with: {
                     path: "/tmp/phpstan"
                     key:  "${{ runner.os }}-phpstan-${{ github.sha }}"
@@ -200,7 +200,7 @@ common.#workflow & {
                 }
             }, {
                 name: "Psalm cache"
-                uses: "actions/cache@v3"
+                uses: "actions/cache@v4"
                 with: {
                     path: "~/.cache/psalm"
                     key:  "${{ runner.os }}-psalm-${{ github.sha }}"
@@ -257,7 +257,7 @@ common.#workflow & {
                 }
             }, {
                 name: "Cache extensions"
-                uses: "actions/cache@v3"
+                uses: "actions/cache@v4"
                 with: {
                     path:           "${{ steps.extcache.outputs.dir }}"
                     key:            "${{ steps.extcache.outputs.key }}"
@@ -275,7 +275,7 @@ common.#workflow & {
             }, {
                 name: "Composer packages from cache"
                 id:   "restore-composer-cache"
-                uses: "actions/cache@v3"
+                uses: "actions/cache@v4"
                 with: {
                     path: "vendor"
                     key:  "${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}"

--- a/pkg/workflows/build-python.cue
+++ b/pkg/workflows/build-python.cue
@@ -5,7 +5,7 @@ import "github.com/goes-funky/workflows/pkg/common"
 #step_setup_python: common.#step & {
     name: "Setup python"
     id:   "setup-python"
-    uses: "actions/setup-python@v4"
+    uses: "actions/setup-python@v5"
     with: {
         "python-version": "${{ inputs.python-version }}"
     }
@@ -43,7 +43,7 @@ import "github.com/goes-funky/workflows/pkg/common"
 #step_setup_deps_cache: common.#step & {
     name: "Setup cache"
     id:   "deps-cache"
-    uses: "actions/cache@v3"
+    uses: "actions/cache@v4"
     with: {
         path: ".venv/"
         key:  "${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}"

--- a/pkg/workflows/workflows.cue
+++ b/pkg/workflows/workflows.cue
@@ -24,7 +24,7 @@ common.#workflow & {
                 {
                     name: "Setup tools cache"
                     id: "cache"
-                    uses: "actions/cache@v3"
+                    uses: "actions/cache@v4"
                     with: {
                         path: "bin"
                         key: "${{ runner.os }}-tools-${{ hashFiles('Makefile') }}"


### PR DESCRIPTION
### What

Upgrade default action versions to use node 20 instead of (deprecated) node 16.