### PR TITLE
chore(BAC-20): replace the deprecated sonar action

### DIFF
--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -314,7 +314,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: '!inputs.skip-sonar && github.event_name != ''pull_request'''
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4
         with:
           args: |-
             -Dsonar.python.coverage.reportPaths=coverage.xml
@@ -326,7 +326,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: '!inputs.skip-sonar && github.event_name != ''push'''
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4
         with:
           args: |-
             -Dsonar.python.coverage.reportPaths=coverage.xml

--- a/pkg/workflows/build-python.cue
+++ b/pkg/workflows/build-python.cue
@@ -252,7 +252,7 @@ common.#workflow & {
                         SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}"
                     }
                     if: "!inputs.skip-sonar && github.event_name != 'pull_request'"
-                    uses: "SonarSource/sonarcloud-github-action@master"
+                    uses: "SonarSource/sonarqube-scan-action@v4"
                     with: {
                         args: """
                             -Dsonar.python.coverage.reportPaths=coverage.xml
@@ -269,7 +269,7 @@ common.#workflow & {
                         SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}"
                     }
                     if: "!inputs.skip-sonar && github.event_name != 'push'"
-                    uses: "SonarSource/sonarcloud-github-action@master"
+                    uses: "SonarSource/sonarqube-scan-action@v4"
                     with: {
                         args: """
                             -Dsonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
As per https://github.com/SonarSource/sonarcloud-github-action we should switch this action's drop-in replacement `sonarqube-scan-action`